### PR TITLE
GL002 - Fixed draw error with PrimitiveType.LineStrip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ tests/*/*/[Pp]ackages/*
 examples/*/*/[Pp]ackages/*
 */[Pp]ackages/*
 */.vs/*
+*.ide

--- a/Magnesium.OpenGL.DesktopGL/Entrypoint/FullGLCmdDrawEntrypoint.cs
+++ b/Magnesium.OpenGL.DesktopGL/Entrypoint/FullGLCmdDrawEntrypoint.cs
@@ -7,7 +7,7 @@ namespace Magnesium.OpenGL.DesktopGL
 	{
 		#region ICmdDrawCapabilities implementation
 
-		PrimitiveType GetPrimitiveType (MgPrimitiveTopology topology)
+		public static PrimitiveType GetPrimitiveType (MgPrimitiveTopology topology)
 		{
 			switch (topology)
 			{
@@ -21,6 +21,8 @@ namespace Magnesium.OpenGL.DesktopGL
 				return PrimitiveType.LineStrip;
 			case MgPrimitiveTopology.TRIANGLE_FAN:
 				return PrimitiveType.TriangleFan;
+            case MgPrimitiveTopology.TRIANGLE_STRIP:
+                return PrimitiveType.TriangleStrip;
 			case MgPrimitiveTopology.LINE_LIST_WITH_ADJACENCY:
 				return PrimitiveType.LinesAdjacency;
 			case MgPrimitiveTopology.LINE_STRIP_WITH_ADJACENCY:

--- a/Magnesium.OpenGL.DesktopGL/Magnesium.OpenGL.DesktopGL.csproj
+++ b/Magnesium.OpenGL.DesktopGL/Magnesium.OpenGL.DesktopGL.csproj
@@ -128,12 +128,6 @@
     <Folder Include="CommandBuffer\" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Magnesium, Version=5.2.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Build\packages\Magnesium.5.2.7-alpha\lib\portable45-net45+win8+wpa81\Magnesium.dll</HintPath>
-    </Reference>
-    <Reference Include="Magnesium.OpenGL, Version=6.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Build\packages\Magnesium.OpenGL.6.0.5-alpha\lib\portable45-net45+win8+wpa81\Magnesium.OpenGL.dll</HintPath>
-    </Reference>
     <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>..\Build\packages\OpenTK.2.0.0\lib\net20\OpenTK.dll</HintPath>
       <Private>True</Private>
@@ -145,5 +139,15 @@
   <ItemGroup>
     <None Include="OpenTK.dll.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Magnesium.OpenGL\Magnesium.OpenGL.csproj">
+      <Project>{84924a0f-0d4c-4b0c-b16a-4f26dd838af2}</Project>
+      <Name>Magnesium.OpenGL</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Magnesium\Magnesium.csproj">
+      <Project>{9f9ac448-9d17-43e5-8889-285426290891}</Project>
+      <Name>Magnesium</Name>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/Magnesium.OpenGL/Magnesium.OpenGL.csproj
+++ b/Magnesium.OpenGL/Magnesium.OpenGL.csproj
@@ -243,12 +243,10 @@
     <Compile Include="Queue\IGLRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Magnesium, Version=5.2.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Build\packages\Magnesium.5.2.7-alpha\lib\portable45-net45+win8+wpa81\Magnesium.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <ProjectReference Include="..\Magnesium\Magnesium.csproj">
+      <Project>{9f9ac448-9d17-43e5-8889-285426290891}</Project>
+      <Name>Magnesium</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/Magnesium.OpenGL/packages.config
+++ b/Magnesium.OpenGL/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Magnesium" version="5.2.8-beta" targetFramework="portable45-net45+win8+wpa81" />
-</packages>

--- a/tests/GL002/GL002.Demo/App.config
+++ b/tests/GL002/GL002.Demo/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    </startup>
+</configuration>

--- a/tests/GL002/GL002.Demo/GL002.Demo.csproj
+++ b/tests/GL002/GL002.Demo/GL002.Demo.csproj
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{3177B351-BD6A-46C2-A989-EBD66BA965B5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TriangleDemo.DesktopGL</RootNamespace>
+    <AssemblyName>TriangleDemo.DesktopGL</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="LightInject, Version=4.1.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\LightInject.4.1.5\lib\net45\LightInject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Magnesium, Version=5.2.8.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Magnesium.5.2.8-beta\lib\portable45-net45+win8+wpa81\Magnesium.dll</HintPath>
+    </Reference>
+    <Reference Include="Magnesium.PresentationSurfaces.OpenTK, Version=1.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Magnesium.PresentationSurfaces.OpenTK.1.0.4-beta\lib\net45\Magnesium.PresentationSurfaces.OpenTK.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenTK.2.0.0\lib\net20\OpenTK.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GameWindow.cs" />
+    <Compile Include="GLSLTriangleShaderPath.cs" />
+    <Compile Include="ITriangleShaderPath.cs" />
+    <Compile Include="Matrix4.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Vector3.cs" />
+    <Compile Include="Vector4.cs" />
+    <Compile Include="VulkanExample.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="OpenTK.dll.config" />
+    <None Include="packages.config" />
+    <None Include="Shaders\triangle.frag">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Shaders\triangle.vert">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Magnesium.OpenGL.DesktopGL\Magnesium.OpenGL.DesktopGL.csproj">
+      <Project>{156d7f9d-1243-4edb-9e45-24faf2f40a4c}</Project>
+      <Name>Magnesium.OpenGL.DesktopGL</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Magnesium.OpenGL\Magnesium.OpenGL.csproj">
+      <Project>{84924a0f-0d4c-4b0c-b16a-4f26dd838af2}</Project>
+      <Name>Magnesium.OpenGL</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/GL002/GL002.Demo/GLSLTriangleShaderPath.cs
+++ b/tests/GL002/GL002.Demo/GLSLTriangleShaderPath.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.IO;
+
+namespace TriangleDemo.DesktopGL
+{
+    internal class GLSLTriangleShaderPath : ITriangleDemoShaderPath
+    {
+        public Stream OpenFragmentShader()
+        {
+            return System.IO.File.OpenRead("shaders/triangle.frag");
+        }
+
+        public Stream OpenVertexShader()
+        {
+            return System.IO.File.OpenRead("shaders/triangle.vert");
+        }
+    }
+}

--- a/tests/GL002/GL002.Demo/GameWindow.cs
+++ b/tests/GL002/GL002.Demo/GameWindow.cs
@@ -1,0 +1,617 @@
+﻿using OpenTK;
+using System;
+using System.Diagnostics;
+
+//
+// David Young 2016
+// Code taken from the GameWindow.cs, INativeWindow.cs, NativeWindow.cs
+// 
+// The Open Toolkit Library License
+//
+// Copyright (c) 2006 - 2009 the Open Toolkit library.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights to 
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace TriangleDemo
+{
+    class GameWindow : IDisposable
+    {
+        const double MaxFrequency = 500.0; // Frequency cap for Update/RenderFrame events
+
+        readonly Stopwatch watch = new Stopwatch();
+
+        double target_update_period, target_render_period;
+
+        private INativeWindow implementation;
+
+        bool isExiting = false;
+        bool events;
+
+        /// <summary>
+        /// System.Threading.Thread.CurrentThread.ManagedThreadId of the thread that created this <see cref="OpenTK.NativeWindow"/>.
+        /// </summary>
+        private int thread_id;
+
+        //private bool events;
+
+        double update_period;
+        double render_period;
+        double update_timestamp; // timestamp of last UpdateFrame event
+        double render_timestamp; // timestamp of last RenderFrame event
+        double update_epsilon; // quantization error for UpdateFrame events
+
+        double render_time; // length of last RenderFrame event
+        double update_time; // length of last UpdateFrame event
+
+        bool is_running_slowly; // true, when UpdatePeriod cannot reach TargetUpdatePeriod
+
+        public GameWindow(INativeWindow window)
+        {
+            implementation = window;
+
+            this.thread_id = System.Threading.Thread.CurrentThread.ManagedThreadId;
+        }
+
+        #region EnsureUndisposed
+
+        /// <summary>
+        /// Ensures that this NativeWindow has not been disposed.
+        /// </summary>
+        /// <exception cref="System.ObjectDisposedException">
+        /// If this NativeWindow has been disposed.
+        /// </exception>
+        protected void EnsureUndisposed()
+        {
+            if (mIsDisposed) throw new ObjectDisposedException(GetType().Name);
+        }
+
+        #endregion
+
+
+        #region Visible
+
+        /// <summary>
+        /// Gets or sets a System.Boolean that indicates whether this NativeWindow is visible.
+        /// </summary>
+        public bool Visible
+        {
+            get
+            {
+                EnsureUndisposed();
+                return implementation.Visible;
+            }
+            set
+            {
+                EnsureUndisposed();
+                implementation.Visible = value;
+            }
+        }
+
+        #endregion
+
+        #region TargetUpdatePeriod
+
+        /// <summary>
+        /// Gets or sets a double representing the target update period, in seconds.
+        /// </summary>
+        /// <remarks>
+        /// <para>A value of 0.0 indicates that UpdateFrame events are generated at the maximum possible frequency (i.e. only limited by the hardware's capabilities).</para>
+        /// <para>Values lower than 0.002 seconds (500Hz) are clamped to 0.0. Values higher than 1.0 seconds (1Hz) are clamped to 1.0.</para>
+        /// </remarks>
+        public double TargetUpdatePeriod
+        {
+            get
+            {
+                EnsureUndisposed();
+                return target_update_period;
+            }
+            set
+            {
+                EnsureUndisposed();
+                if (value <= 1 / MaxFrequency)
+                {
+                    target_update_period = 0.0;
+                }
+                else if (value <= 1.0)
+                {
+                    target_update_period = value;
+                }
+                else Debug.Print("Target update period clamped to 1.0 seconds.");
+            }
+        }
+
+        #endregion
+
+        #region TargetUpdateFrequency
+
+        /// <summary>
+        /// Gets or sets a double representing the target update frequency, in hertz.
+        /// </summary>
+        /// <remarks>
+        /// <para>A value of 0.0 indicates that UpdateFrame events are generated at the maximum possible frequency (i.e. only limited by the hardware's capabilities).</para>
+        /// <para>Values lower than 1.0Hz are clamped to 0.0. Values higher than 500.0Hz are clamped to 500.0Hz.</para>
+        /// </remarks>
+        public double TargetUpdateFrequency
+        {
+            get
+            {
+                EnsureUndisposed();
+                if (TargetUpdatePeriod == 0.0)
+                    return 0.0;
+                return 1.0 / TargetUpdatePeriod;
+            }
+            set
+            {
+                EnsureUndisposed();
+                if (value < 1.0)
+                {
+                    TargetUpdatePeriod = 0.0;
+                }
+                else if (value <= MaxFrequency)
+                {
+                    TargetUpdatePeriod = 1.0 / value;
+                }
+                else Debug.Print("Target render frequency clamped to {0}Hz.", MaxFrequency);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Enters the game loop of the GameWindow updating and rendering at the specified frequency.
+        /// </summary>
+        /// <remarks>
+        /// When overriding the default game loop you should call ProcessEvents()
+        /// to ensure that your GameWindow responds to operating system events.
+        /// <para>
+        /// Once ProcessEvents() returns, it is time to call update and render the next frame.
+        /// </para>
+        /// </remarks>
+        /// <param name="updates_per_second">The frequency of UpdateFrame events.</param>
+        /// <param name="frames_per_second">The frequency of RenderFrame events.</param>
+        public void Run(double updates_per_second, double frames_per_second)
+        {
+            EnsureUndisposed();
+
+            try
+            {
+                if (updates_per_second < 0.0 || updates_per_second > 200.0)
+                    throw new ArgumentOutOfRangeException("updates_per_second", updates_per_second,
+                                                          "Parameter should be inside the range [0.0, 200.0]");
+                if (frames_per_second < 0.0 || frames_per_second > 200.0)
+                    throw new ArgumentOutOfRangeException("frames_per_second", frames_per_second,
+                                                          "Parameter should be inside the range [0.0, 200.0]");
+
+                if (updates_per_second != 0)
+                {
+                    TargetUpdateFrequency = updates_per_second;
+                }
+                if (frames_per_second != 0)
+                {
+                    TargetRenderFrequency = frames_per_second;
+                }
+
+                Visible = true;   // Make sure the GameWindow is visible.
+                //OnLoadInternal(EventArgs.Empty);
+                //OnResize(EventArgs.Empty);
+
+                // On some platforms, ProcessEvents() does not return while the user is resizing or moving
+                // the window. We can avoid this issue by raising UpdateFrame and RenderFrame events
+                // whenever we encounter a size or move event.
+                // Note: hack disabled. Threaded rendering provides a better solution to this issue.
+                //Move += DispatchUpdateAndRenderFrame;
+                //Resize += DispatchUpdateAndRenderFrame;
+
+                Debug.Print("Entering main loop.");
+                watch.Start();
+                while (true)
+                {
+                    ProcessEvents(false);
+                    if (Exists && !IsExiting)
+                        DispatchUpdateAndRenderFrame(this, EventArgs.Empty);
+                    else
+                        return;
+                }
+            }
+            finally
+            {
+                Move -= DispatchUpdateAndRenderFrame;
+                Resize -= DispatchUpdateAndRenderFrame;
+
+                if (Exists)
+                {
+                    // TODO: Should similar behaviour be retained, possibly on native window level?
+                    //while (this.Exists)
+                    //    ProcessEvents(false);
+                }
+            }
+        }
+
+        /// <summary>This member is not supported.</summary>
+        /// <value>To be added.</value>
+        /// <remarks>
+        ///   <para>
+        ///     Throws a <see cref="T:System.NotSupportedException" />.
+        ///   </para>
+        /// </remarks>
+        public event EventHandler<EventArgs> Move = delegate { };
+
+        /// <summary>
+        ///   Occurs when the view's
+        ///   <see cref="P:OpenTK.Platform.Android.AndroidGameView.Size" />
+        ///   changes.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        public event EventHandler<EventArgs> Resize = delegate { };
+
+        void DispatchUpdateAndRenderFrame(object sender, EventArgs e)
+        {
+            int is_running_slowly_retries = 4;
+            double timestamp = watch.Elapsed.TotalSeconds;
+            double elapsed = 0;
+
+            elapsed = ClampElapsed(timestamp - update_timestamp);
+            while (elapsed > 0 && elapsed + update_epsilon >= TargetUpdatePeriod)
+            {
+                RaiseUpdateFrame(elapsed, ref timestamp);
+
+                // Calculate difference (positive or negative) between
+                // actual elapsed time and target elapsed time. We must
+                // compensate for this difference.
+                update_epsilon += elapsed - TargetUpdatePeriod;
+
+                // Prepare for next loop
+                elapsed = ClampElapsed(timestamp - update_timestamp);
+
+                if (TargetUpdatePeriod <= Double.Epsilon)
+                {
+                    // According to the TargetUpdatePeriod documentation,
+                    // a TargetUpdatePeriod of zero means we will raise
+                    // UpdateFrame events as fast as possible (one event
+                    // per ProcessEvents() call)
+                    break;
+                }
+
+                is_running_slowly = update_epsilon >= TargetUpdatePeriod;
+                if (is_running_slowly && --is_running_slowly_retries == 0)
+                {
+                    // If UpdateFrame consistently takes longer than TargetUpdateFrame
+                    // stop raising events to avoid hanging inside the UpdateFrame loop.
+                    break;
+                }
+            }
+
+            elapsed = ClampElapsed(timestamp - render_timestamp);
+            if (elapsed > 0 && elapsed >= TargetRenderPeriod)
+            {
+                RaiseRenderFrame(elapsed, ref timestamp);
+            }
+        }
+
+        void RaiseUpdateFrame(double elapsed, ref double timestamp)
+        {
+            // Raise UpdateFrame event
+            OnUpdateFrameInternal(new FrameEventArgs(elapsed));
+
+            // Update UpdatePeriod/UpdateFrequency properties
+            update_period = elapsed;
+
+            // Update UpdateTime property
+            update_timestamp = timestamp;
+            timestamp = watch.Elapsed.TotalSeconds;
+            update_time = timestamp - update_timestamp;
+        }
+
+        /// <summary>
+        /// Occurs when it is time to update a frame.
+        /// </summary>
+        public event EventHandler<FrameEventArgs> UpdateFrame = delegate { };
+
+        #region OnUpdateFrame
+
+        /// <summary>
+        /// Called when the frame is updated.
+        /// </summary>
+        /// <param name="e">Contains information necessary for frame updating.</param>
+        /// <remarks>
+        /// Subscribe to the <see cref="UpdateFrame"/> event instead of overriding this method.
+        /// </remarks>
+        protected virtual void OnUpdateFrame(FrameEventArgs e)
+        {
+            UpdateFrame(this, e);
+        }
+
+        #endregion
+
+        #region OnUpdateFrameInternal
+
+        private void OnUpdateFrameInternal(FrameEventArgs e) { if (Exists && !isExiting) OnUpdateFrame(e); }
+
+        #endregion
+
+        public event EventHandler<FrameEventArgs> RenderFrame = delegate { };
+
+        #region OnRenderFrame
+
+        /// <summary>
+        /// Called when the frame is rendered.
+        /// </summary>
+        /// <param name="e">Contains information necessary for frame rendering.</param>
+        /// <remarks>
+        /// Subscribe to the <see cref="RenderFrame"/> event instead of overriding this method.
+        /// </remarks>
+        protected virtual void OnRenderFrame(FrameEventArgs e)
+        {
+            RenderFrame(this, e);
+        }
+
+        #endregion
+
+        #region OnRenderFrameInternal
+
+        private void OnRenderFrameInternal(FrameEventArgs e) { if (Exists && !isExiting) OnRenderFrame(e); }
+
+        #endregion
+
+        void RaiseRenderFrame(double elapsed, ref double timestamp)
+        {
+            // Raise RenderFrame event
+            OnRenderFrameInternal(new FrameEventArgs(elapsed));
+
+            // Update RenderPeriod/UpdateFrequency properties
+            render_period = elapsed;
+
+            // Update RenderTime property
+            render_timestamp = timestamp;
+            timestamp = watch.Elapsed.TotalSeconds;
+            render_time = timestamp - render_timestamp;
+        }
+
+        double ClampElapsed(double elapsed)
+        {
+            return MathHelper.Clamp(elapsed, 0.0, 1.0);
+        }
+
+        #region IsExiting
+
+        /// <summary>
+        /// Gets a value indicating whether the shutdown sequence has been initiated
+        /// for this window, by calling GameWindow.Exit() or hitting the 'close' button.
+        /// If this property is true, it is no longer safe to use any OpenTK.Input or
+        /// OpenTK.Graphics.OpenGL functions or properties.
+        /// </summary>
+        public bool IsExiting
+        {
+            get
+            {
+                EnsureUndisposed();
+                return isExiting;
+            }
+        }
+
+        #endregion
+
+        #region Exists
+
+        /// <summary>
+        /// Gets a value indicating whether a render window exists.
+        /// </summary>
+        public bool Exists
+        {
+            get
+            {
+                return mIsDisposed ? false : implementation.Exists; // TODO: Should disposed be ignored instead?
+            }
+        }
+
+        #endregion
+
+        #region ProcessEvents
+
+        /// <summary>
+        /// Processes operating system events until the NativeWindow becomes idle.
+        /// </summary>
+        /// <param name="retainEvents">If true, the state of underlying system event propagation will be preserved, otherwise event propagation will be enabled if it has not been already.</param>
+        protected void ProcessEvents(bool retainEvents)
+        {
+            EnsureUndisposed();
+            if (this.thread_id != System.Threading.Thread.CurrentThread.ManagedThreadId)
+            {
+                throw new InvalidOperationException("ProcessEvents must be called on the same thread that created the window.");
+            }
+            if (!retainEvents && !events) Events = true;
+            implementation.ProcessEvents();
+        }
+
+        #endregion
+
+        #region OnMove
+
+        /// <summary>
+        /// Called when the NativeWindow is moved.
+        /// </summary>
+        /// <param name="e">Not used.</param>
+        protected virtual void OnMove(EventArgs e)
+        {
+            Move(this, e);
+        }
+
+        #endregion
+
+        #region OnMoveInternal
+
+        private void OnMoveInternal(object sender, EventArgs e) { OnMove(e); }
+
+        #endregion
+
+        #region OnResize
+
+        /// <summary>
+        /// Called when the NativeWindow is resized.
+        /// </summary>
+        /// <param name="e">Not used.</param>
+        protected virtual void OnResize(EventArgs e)
+        {
+            Resize(this, e);
+        }
+
+        #endregion
+
+        #region OnResizeInternal
+
+        private void OnResizeInternal(object sender, EventArgs e) { OnResize(e); }
+
+        #endregion
+
+        #region Events
+
+        private bool Events
+        {
+            set
+            {
+                if (value)
+                {
+                    if (events)
+                    {
+                        throw new InvalidOperationException("Event propagation is already enabled.");
+                    }
+                    implementation.Move += OnMoveInternal;
+                    implementation.Resize += OnResizeInternal;
+                    events = true;
+                }
+                else if (events)
+                {
+                    implementation.Move -= OnMoveInternal;
+                    implementation.Resize -= OnResizeInternal;
+                    events = false;
+                }
+                else
+                {
+                    throw new InvalidOperationException("Event propagation is already disabled.");
+                }
+            }
+        }
+
+        #endregion
+
+
+        #region TargetRenderFrequency
+
+        /// <summary>
+        /// Gets or sets a double representing the target render frequency, in hertz.
+        /// </summary>
+        /// <remarks>
+        /// <para>A value of 0.0 indicates that RenderFrame events are generated at the maximum possible frequency (i.e. only limited by the hardware's capabilities).</para>
+        /// <para>Values lower than 1.0Hz are clamped to 0.0. Values higher than 500.0Hz are clamped to 200.0Hz.</para>
+        /// </remarks>
+        public double TargetRenderFrequency
+        {
+            get
+            {
+                EnsureUndisposed();
+                if (TargetRenderPeriod == 0.0)
+                    return 0.0;
+                return 1.0 / TargetRenderPeriod;
+            }
+            set
+            {
+                EnsureUndisposed();
+                if (value < 1.0)
+                {
+                    TargetRenderPeriod = 0.0;
+                }
+                else if (value <= MaxFrequency)
+                {
+                    TargetRenderPeriod = 1.0 / value;
+                }
+                else Debug.Print("Target render frequency clamped to {0}Hz.", MaxFrequency);
+            }
+        }
+
+        #endregion
+
+        #region TargetRenderPeriod
+
+        /// <summary>
+        /// Gets or sets a double representing the target render period, in seconds.
+        /// </summary>
+        /// <remarks>
+        /// <para>A value of 0.0 indicates that RenderFrame events are generated at the maximum possible frequency (i.e. only limited by the hardware's capabilities).</para>
+        /// <para>Values lower than 0.002 seconds (500Hz) are clamped to 0.0. Values higher than 1.0 seconds (1Hz) are clamped to 1.0.</para>
+        /// </remarks>
+        public double TargetRenderPeriod
+        {
+            get
+            {
+                EnsureUndisposed();
+                return target_render_period;
+            }
+            set
+            {
+                EnsureUndisposed();
+                if (value <= 1 / MaxFrequency)
+                {
+                    target_render_period = 0.0;
+                }
+                else if (value <= 1.0)
+                {
+                    target_render_period = value;
+                }
+                else Debug.Print("Target render period clamped to 1.0 seconds.");
+            }
+        }
+
+        #endregion
+
+        #region IDisposable Support
+        private bool mIsDisposed = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (mIsDisposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                // TODO: dispose managed state (managed objects).
+            }
+
+            // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+            // TODO: set large fields to null.
+
+            mIsDisposed = true;
+            
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/tests/GL002/GL002.Demo/ITriangleShaderPath.cs
+++ b/tests/GL002/GL002.Demo/ITriangleShaderPath.cs
@@ -1,0 +1,10 @@
+﻿using System.IO;
+
+namespace TriangleDemo
+{
+    public interface ITriangleDemoShaderPath
+    {
+        Stream OpenVertexShader();
+        Stream OpenFragmentShader();
+    }
+}

--- a/tests/GL002/GL002.Demo/Matrix4.cs
+++ b/tests/GL002/GL002.Demo/Matrix4.cs
@@ -1,0 +1,2240 @@
+// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Diagnostics;
+
+namespace TriangleDemo
+{
+    /// <summary>
+    /// Represents the right-handed 4x4 floating point matrix, which can store translation, scale and rotation information.
+    /// </summary>
+    [DebuggerDisplay("{DebugDisplayString,nq}")]
+    public struct Matrix4 : IEquatable<Matrix4>
+    {
+        #region Public Constructors
+
+        /// <summary>
+        /// Constructs a matrix.
+        /// </summary>
+        /// <param name="m11">A first row and first column value.</param>
+        /// <param name="m12">A first row and second column value.</param>
+        /// <param name="m13">A first row and third column value.</param>
+        /// <param name="m14">A first row and fourth column value.</param>
+        /// <param name="m21">A second row and first column value.</param>
+        /// <param name="m22">A second row and second column value.</param>
+        /// <param name="m23">A second row and third column value.</param>
+        /// <param name="m24">A second row and fourth column value.</param>
+        /// <param name="m31">A third row and first column value.</param>
+        /// <param name="m32">A third row and second column value.</param>
+        /// <param name="m33">A third row and third column value.</param>
+        /// <param name="m34">A third row and fourth column value.</param>
+        /// <param name="m41">A fourth row and first column value.</param>
+        /// <param name="m42">A fourth row and second column value.</param>
+        /// <param name="m43">A fourth row and third column value.</param>
+        /// <param name="m44">A fourth row and fourth column value.</param>
+        public Matrix4(float m11, float m12, float m13, float m14, float m21, float m22, float m23, float m24, float m31,
+                      float m32, float m33, float m34, float m41, float m42, float m43, float m44)
+        {
+            this.M11 = m11;
+            this.M12 = m12;
+            this.M13 = m13;
+            this.M14 = m14;
+            this.M21 = m21;
+            this.M22 = m22;
+            this.M23 = m23;
+            this.M24 = m24;
+            this.M31 = m31;
+            this.M32 = m32;
+            this.M33 = m33;
+            this.M34 = m34;
+            this.M41 = m41;
+            this.M42 = m42;
+            this.M43 = m43;
+            this.M44 = m44;
+        }
+
+        /// <summary>
+        /// Constructs a matrix.
+        /// </summary>
+        /// <param name="row1">A first row of the created matrix.</param>
+        /// <param name="row2">A second row of the created matrix.</param>
+        /// <param name="row3">A third row of the created matrix.</param>
+        /// <param name="row4">A fourth row of the created matrix.</param>
+        public Matrix4(Vector4 row1, Vector4 row2, Vector4 row3, Vector4 row4)
+        {
+            this.M11 = row1.X;
+            this.M12 = row1.Y;
+            this.M13 = row1.Z;
+            this.M14 = row1.W;
+            this.M21 = row2.X;
+            this.M22 = row2.Y;
+            this.M23 = row2.Z;
+            this.M24 = row2.W;
+            this.M31 = row3.X;
+            this.M32 = row3.Y;
+            this.M33 = row3.Z;
+            this.M34 = row3.W;
+            this.M41 = row4.X;
+            this.M42 = row4.Y;
+            this.M43 = row4.Z;
+            this.M44 = row4.W;
+        }
+
+        #endregion
+
+        #region Public Fields
+
+        /// <summary>
+        /// A first row and first column value.
+        /// </summary>
+        public float M11;
+
+        /// <summary>
+        /// A first row and second column value.
+        /// </summary>
+        public float M12;
+
+        /// <summary>
+        /// A first row and third column value.
+        /// </summary>
+        public float M13;
+
+        /// <summary>
+        /// A first row and fourth column value.
+        /// </summary>
+        public float M14;
+
+        /// <summary>
+        /// A second row and first column value.
+        /// </summary>
+        public float M21;
+
+        /// <summary>
+        /// A second row and second column value.
+        /// </summary>
+        public float M22;
+
+        /// <summary>
+        /// A second row and third column value.
+        /// </summary>
+        public float M23;
+
+        /// <summary>
+        /// A second row and fourth column value.
+        /// </summary>
+        public float M24;
+
+        /// <summary>
+        /// A third row and first column value.
+        /// </summary>
+        public float M31;
+
+        /// <summary>
+        /// A third row and second column value.
+        /// </summary>
+        public float M32;
+
+        /// <summary>
+        /// A third row and third column value.
+        /// </summary>
+        public float M33;
+
+        /// <summary>
+        /// A third row and fourth column value.
+        /// </summary>
+        public float M34;
+
+        /// <summary>
+        /// A fourth row and first column value.
+        /// </summary>
+        public float M41;
+
+        /// <summary>
+        /// A fourth row and second column value.
+        /// </summary>
+        public float M42;
+
+        /// <summary>
+        /// A fourth row and third column value.
+        /// </summary>
+        public float M43;
+
+        /// <summary>
+        /// A fourth row and fourth column value.
+        /// </summary>
+        public float M44;
+
+        #endregion
+
+        #region Indexers
+
+        public float this[int index]
+        {
+            get
+            {
+                switch (index)
+                {
+                    case 0: return M11;
+                    case 1: return M12;
+                    case 2: return M13;
+                    case 3: return M14;
+                    case 4: return M21;
+                    case 5: return M22;
+                    case 6: return M23;
+                    case 7: return M24;
+                    case 8: return M31;
+                    case 9: return M32;
+                    case 10: return M33;
+                    case 11: return M34;
+                    case 12: return M41;
+                    case 13: return M42;
+                    case 14: return M43;
+                    case 15: return M44;
+                }
+                throw new ArgumentOutOfRangeException();
+            }
+
+            set
+            {
+                switch (index)
+                {
+                    case 0: M11 = value; break;
+                    case 1: M12 = value; break;
+                    case 2: M13 = value; break;
+                    case 3: M14 = value; break;
+                    case 4: M21 = value; break;
+                    case 5: M22 = value; break;
+                    case 6: M23 = value; break;
+                    case 7: M24 = value; break;
+                    case 8: M31 = value; break;
+                    case 9: M32 = value; break;
+                    case 10: M33 = value; break;
+                    case 11: M34 = value; break;
+                    case 12: M41 = value; break;
+                    case 13: M42 = value; break;
+                    case 14: M43 = value; break;
+                    case 15: M44 = value; break;
+                    default: throw new ArgumentOutOfRangeException();
+                }
+            }
+        }
+
+        public float this[int row, int column]
+        {
+            get
+            {
+                return this[(row * 4) + column];
+            }
+
+            set
+            {
+                this[(row * 4) + column] = value;
+            }
+        }
+
+        #endregion
+
+        #region Private Members
+		private static Matrix4 mIdentity = new Matrix4(1f, 0f, 0f, 0f, 
+		                                            0f, 1f, 0f, 0f, 
+		                                            0f, 0f, 1f, 0f, 
+		                                            0f, 0f, 0f, 1f);
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// The backward vector formed from the third row M31, M32, M33 elements.
+        /// </summary>
+        public Vector3 Backward
+        {
+            get
+            {
+                return new Vector3(this.M31, this.M32, this.M33);
+            }
+            set
+            {
+                this.M31 = value.X;
+                this.M32 = value.Y;
+                this.M33 = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// The down vector formed from the second row -M21, -M22, -M23 elements.
+        /// </summary>
+        public Vector3 Down
+        {
+            get
+            {
+                return new Vector3(-this.M21, -this.M22, -this.M23);
+            }
+            set
+            {
+                this.M21 = -value.X;
+                this.M22 = -value.Y;
+                this.M23 = -value.Z;
+            }
+        }
+
+        /// <summary>
+        /// The forward vector formed from the third row -M31, -M32, -M33 elements.
+        /// </summary>
+        public Vector3 Forward
+        {
+            get
+            {
+                return new Vector3(-this.M31, -this.M32, -this.M33);
+            }
+            set
+            {
+                this.M31 = -value.X;
+                this.M32 = -value.Y;
+                this.M33 = -value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Returns the identity matrix.
+        /// </summary>
+        public static Matrix4 Identity
+        {
+            get { return mIdentity; }
+        }
+
+        /// <summary>
+        /// The left vector formed from the first row -M11, -M12, -M13 elements.
+        /// </summary>
+        public Vector3 Left
+        {
+            get
+            {
+                return new Vector3(-this.M11, -this.M12, -this.M13);
+            }
+            set
+            {
+                this.M11 = -value.X;
+                this.M12 = -value.Y;
+                this.M13 = -value.Z;
+            }
+        }
+
+        /// <summary>
+        /// The right vector formed from the first row M11, M12, M13 elements.
+        /// </summary>
+        public Vector3 Right
+        {
+            get
+            {
+                return new Vector3(this.M11, this.M12, this.M13);
+            }
+            set
+            {
+                this.M11 = value.X;
+                this.M12 = value.Y;
+                this.M13 = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Position stored in this matrix.
+        /// </summary>
+        public Vector3 Translation
+        {
+            get
+            {
+                return new Vector3(this.M41, this.M42, this.M43);
+            }
+            set
+            {
+                this.M41 = value.X;
+                this.M42 = value.Y;
+                this.M43 = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// Scale stored in this matrix.
+        /// </summary>
+        public Vector3 Scale
+        {
+            get
+            {
+                return new Vector3(this.M11, this.M22, this.M33);
+            }
+            set
+            {
+                this.M11 = value.X;
+                this.M22 = value.Y;
+                this.M33 = value.Z;
+            }
+        }
+
+        /// <summary>
+        /// The upper vector formed from the second row M21, M22, M23 elements.
+        /// </summary>
+        public Vector3 Up
+        {
+            get
+            {
+                return new Vector3(this.M21, this.M22, this.M23);
+            }
+            set
+            {
+                this.M21 = value.X;
+                this.M22 = value.Y;
+                this.M23 = value.Z;
+            }
+        }
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> which contains sum of two matrixes.
+        /// </summary>
+        /// <param name="matrix1">The first matrix to add.</param>
+        /// <param name="matrix2">The second matrix to add.</param>
+        /// <returns>The result of the matrix addition.</returns>
+        public static Matrix4 Add(Matrix4 matrix1, Matrix4 matrix2)
+        {
+            matrix1.M11 += matrix2.M11;
+            matrix1.M12 += matrix2.M12;
+            matrix1.M13 += matrix2.M13;
+            matrix1.M14 += matrix2.M14;
+            matrix1.M21 += matrix2.M21;
+            matrix1.M22 += matrix2.M22;
+            matrix1.M23 += matrix2.M23;
+            matrix1.M24 += matrix2.M24;
+            matrix1.M31 += matrix2.M31;
+            matrix1.M32 += matrix2.M32;
+            matrix1.M33 += matrix2.M33;
+            matrix1.M34 += matrix2.M34;
+            matrix1.M41 += matrix2.M41;
+            matrix1.M42 += matrix2.M42;
+            matrix1.M43 += matrix2.M43;
+            matrix1.M44 += matrix2.M44;
+            return matrix1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> which contains sum of two matrixes.
+        /// </summary>
+        /// <param name="matrix1">The first matrix to add.</param>
+        /// <param name="matrix2">The second matrix to add.</param>
+        /// <param name="result">The result of the matrix addition as an output parameter.</param>
+        public static void Add(ref Matrix4 matrix1, ref Matrix4 matrix2, out Matrix4 result)
+        {
+            result.M11 = matrix1.M11 + matrix2.M11;
+            result.M12 = matrix1.M12 + matrix2.M12;
+            result.M13 = matrix1.M13 + matrix2.M13;
+            result.M14 = matrix1.M14 + matrix2.M14;
+            result.M21 = matrix1.M21 + matrix2.M21;
+            result.M22 = matrix1.M22 + matrix2.M22;
+            result.M23 = matrix1.M23 + matrix2.M23;
+            result.M24 = matrix1.M24 + matrix2.M24;
+            result.M31 = matrix1.M31 + matrix2.M31;
+            result.M32 = matrix1.M32 + matrix2.M32;
+            result.M33 = matrix1.M33 + matrix2.M33;
+            result.M34 = matrix1.M34 + matrix2.M34;
+            result.M41 = matrix1.M41 + matrix2.M41;
+            result.M42 = matrix1.M42 + matrix2.M42;
+            result.M43 = matrix1.M43 + matrix2.M43;
+            result.M44 = matrix1.M44 + matrix2.M44;
+
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> for spherical billboarding that rotates around specified object position.
+        /// </summary>
+        /// <param name="objectPosition">Position of billboard object. It will rotate around that vector.</param>
+        /// <param name="cameraPosition">The camera position.</param>
+        /// <param name="cameraUpVector">The camera up vector.</param>
+        /// <param name="cameraForwardVector">Optional camera forward vector.</param>
+        /// <returns>The <see cref="Matrix4"/> for spherical billboarding.</returns>
+        public static Matrix4 CreateBillboard(Vector3 objectPosition, Vector3 cameraPosition,
+            Vector3 cameraUpVector, Nullable<Vector3> cameraForwardVector)
+        {
+            Matrix4 result;
+
+            // Delegate to the other overload of the function to do the work
+            CreateBillboard(ref objectPosition, ref cameraPosition, ref cameraUpVector, cameraForwardVector, out result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> for spherical billboarding that rotates around specified object position.
+        /// </summary>
+        /// <param name="objectPosition">Position of billboard object. It will rotate around that vector.</param>
+        /// <param name="cameraPosition">The camera position.</param>
+        /// <param name="cameraUpVector">The camera up vector.</param>
+        /// <param name="cameraForwardVector">Optional camera forward vector.</param>
+        /// <param name="result">The <see cref="Matrix4"/> for spherical billboarding as an output parameter.</param>
+        public static void CreateBillboard(ref Vector3 objectPosition, ref Vector3 cameraPosition,
+            ref Vector3 cameraUpVector, Vector3? cameraForwardVector, out Matrix4 result)
+        {
+            Vector3 vector;
+            Vector3 vector2;
+            Vector3 vector3;
+            vector.X = objectPosition.X - cameraPosition.X;
+            vector.Y = objectPosition.Y - cameraPosition.Y;
+            vector.Z = objectPosition.Z - cameraPosition.Z;
+            float num = vector.LengthSquared();
+            if (num < 0.0001f)
+            {
+                vector = cameraForwardVector.HasValue ? -cameraForwardVector.Value : Vector3.Forward;
+            }
+            else
+            {
+                Vector3.Multiply(ref vector, (float)(1f / ((float)Math.Sqrt((double)num))), out vector);
+            }
+            Vector3.Cross(ref cameraUpVector, ref vector, out vector3);
+            vector3.Normalize();
+            Vector3.Cross(ref vector, ref vector3, out vector2);
+            result.M11 = vector3.X;
+            result.M12 = vector3.Y;
+            result.M13 = vector3.Z;
+            result.M14 = 0;
+            result.M21 = vector2.X;
+            result.M22 = vector2.Y;
+            result.M23 = vector2.Z;
+            result.M24 = 0;
+            result.M31 = vector.X;
+            result.M32 = vector.Y;
+            result.M33 = vector.Z;
+            result.M34 = 0;
+            result.M41 = objectPosition.X;
+            result.M42 = objectPosition.Y;
+            result.M43 = objectPosition.Z;
+            result.M44 = 1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> for cylindrical billboarding that rotates around specified axis.
+        /// </summary>
+        /// <param name="objectPosition">Object position the billboard will rotate around.</param>
+        /// <param name="cameraPosition">Camera position.</param>
+        /// <param name="rotateAxis">Axis of billboard for rotation.</param>
+        /// <param name="cameraForwardVector">Optional camera forward vector.</param>
+        /// <param name="objectForwardVector">Optional object forward vector.</param>
+        /// <returns>The <see cref="Matrix4"/> for cylindrical billboarding.</returns>
+        public static Matrix4 CreateConstrainedBillboard(Vector3 objectPosition, Vector3 cameraPosition,
+            Vector3 rotateAxis, Nullable<Vector3> cameraForwardVector, Nullable<Vector3> objectForwardVector)
+        {
+            Matrix4 result;
+            CreateConstrainedBillboard(ref objectPosition, ref cameraPosition, ref rotateAxis,
+                cameraForwardVector, objectForwardVector, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> for cylindrical billboarding that rotates around specified axis.
+        /// </summary>
+        /// <param name="objectPosition">Object position the billboard will rotate around.</param>
+        /// <param name="cameraPosition">Camera position.</param>
+        /// <param name="rotateAxis">Axis of billboard for rotation.</param>
+        /// <param name="cameraForwardVector">Optional camera forward vector.</param>
+        /// <param name="objectForwardVector">Optional object forward vector.</param>
+        /// <param name="result">The <see cref="Matrix4"/> for cylindrical billboarding as an output parameter.</param>
+        public static void CreateConstrainedBillboard(ref Vector3 objectPosition, ref Vector3 cameraPosition,
+            ref Vector3 rotateAxis, Vector3? cameraForwardVector, Vector3? objectForwardVector, out Matrix4 result)
+        {
+            float num;
+		    Vector3 vector;
+		    Vector3 vector2;
+		    Vector3 vector3;
+		    vector2.X = objectPosition.X - cameraPosition.X;
+		    vector2.Y = objectPosition.Y - cameraPosition.Y;
+		    vector2.Z = objectPosition.Z - cameraPosition.Z;
+		    float num2 = vector2.LengthSquared();
+		    if (num2 < 0.0001f)
+		    {
+		        vector2 = cameraForwardVector.HasValue ? -cameraForwardVector.Value : Vector3.Forward;
+		    }
+		    else
+		    {
+		        Vector3.Multiply(ref vector2, (float) (1f / ((float) Math.Sqrt((double) num2))), out vector2);
+		    }
+		    Vector3 vector4 = rotateAxis;
+		    Vector3.Dot(ref rotateAxis, ref vector2, out num);
+		    if (Math.Abs(num) > 0.9982547f)
+		    {
+		        if (objectForwardVector.HasValue)
+		        {
+		            vector = objectForwardVector.Value;
+		            Vector3.Dot(ref rotateAxis, ref vector, out num);
+		            if (Math.Abs(num) > 0.9982547f)
+		            {
+		                num = ((rotateAxis.X * Vector3.Forward.X) + (rotateAxis.Y * Vector3.Forward.Y)) + (rotateAxis.Z * Vector3.Forward.Z);
+		                vector = (Math.Abs(num) > 0.9982547f) ? Vector3.Right : Vector3.Forward;
+		            }
+		        }
+		        else
+		        {
+		            num = ((rotateAxis.X * Vector3.Forward.X) + (rotateAxis.Y * Vector3.Forward.Y)) + (rotateAxis.Z * Vector3.Forward.Z);
+		            vector = (Math.Abs(num) > 0.9982547f) ? Vector3.Right : Vector3.Forward;
+		        }
+		        Vector3.Cross(ref rotateAxis, ref vector, out vector3);
+		        vector3.Normalize();
+		        Vector3.Cross(ref vector3, ref rotateAxis, out vector);
+		        vector.Normalize();
+		    }
+		    else
+		    {
+		        Vector3.Cross(ref rotateAxis, ref vector2, out vector3);
+		        vector3.Normalize();
+		        Vector3.Cross(ref vector3, ref vector4, out vector);
+		        vector.Normalize();
+		    }
+		    result.M11 = vector3.X;
+		    result.M12 = vector3.Y;
+		    result.M13 = vector3.Z;
+		    result.M14 = 0;
+		    result.M21 = vector4.X;
+		    result.M22 = vector4.Y;
+		    result.M23 = vector4.Z;
+		    result.M24 = 0;
+		    result.M31 = vector.X;
+		    result.M32 = vector.Y;
+		    result.M33 = vector.Z;
+		    result.M34 = 0;
+		    result.M41 = objectPosition.X;
+		    result.M42 = objectPosition.Y;
+		    result.M43 = objectPosition.Z;
+		    result.M44 = 1;
+
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> which contains the rotation moment around specified axis.
+        /// </summary>
+        /// <param name="axis">The axis of rotation.</param>
+        /// <param name="angle">The angle of rotation in radians.</param>
+        /// <returns>The rotation <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateFromAxisAngle(Vector3 axis, float angle)
+        {
+            Matrix4 result;
+            CreateFromAxisAngle(ref axis, angle, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> which contains the rotation moment around specified axis.
+        /// </summary>
+        /// <param name="axis">The axis of rotation.</param>
+        /// <param name="angle">The angle of rotation in radians.</param>
+        /// <param name="result">The rotation <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateFromAxisAngle(ref Vector3 axis, float angle, out Matrix4 result)
+        {
+            float x = axis.X;
+		    float y = axis.Y;
+		    float z = axis.Z;
+		    float num2 = (float) Math.Sin((double) angle);
+		    float num = (float) Math.Cos((double) angle);
+		    float num11 = x * x;
+		    float num10 = y * y;
+		    float num9 = z * z;
+		    float num8 = x * y;
+		    float num7 = x * z;
+		    float num6 = y * z;
+		    result.M11 = num11 + (num * (1f - num11));
+		    result.M12 = (num8 - (num * num8)) + (num2 * z);
+		    result.M13 = (num7 - (num * num7)) - (num2 * y);
+		    result.M14 = 0;
+		    result.M21 = (num8 - (num * num8)) - (num2 * z);
+		    result.M22 = num10 + (num * (1f - num10));
+		    result.M23 = (num6 - (num * num6)) + (num2 * x);
+		    result.M24 = 0;
+		    result.M31 = (num7 - (num * num7)) + (num2 * y);
+		    result.M32 = (num6 - (num * num6)) - (num2 * x);
+		    result.M33 = num9 + (num * (1f - num9));
+		    result.M34 = 0;
+		    result.M41 = 0;
+		    result.M42 = 0;
+		    result.M43 = 0;
+		    result.M44 = 1;
+        }
+
+        /// <summary>
+        /// Creates a new viewing <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="cameraPosition">Position of the camera.</param>
+        /// <param name="cameraTarget">Lookup vector of the camera.</param>
+        /// <param name="cameraUpVector">The direction of the upper edge of the camera.</param>
+        /// <returns>The viewing <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateLookAt(Vector3 cameraPosition, Vector3 cameraTarget, Vector3 cameraUpVector)
+        {
+            Matrix4 matrix;
+            CreateLookAt(ref cameraPosition, ref cameraTarget, ref cameraUpVector, out matrix);
+            return matrix;
+        }
+
+        /// <summary>
+        /// Creates a new viewing <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="cameraPosition">Position of the camera.</param>
+        /// <param name="cameraTarget">Lookup vector of the camera.</param>
+        /// <param name="cameraUpVector">The direction of the upper edge of the camera.</param>
+        /// <param name="result">The viewing <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateLookAt(ref Vector3 cameraPosition, ref Vector3 cameraTarget, ref Vector3 cameraUpVector, out Matrix4 result)
+        {
+            var vector = Vector3.Normalize(cameraPosition - cameraTarget);
+            var vector2 = Vector3.Normalize(Vector3.Cross(cameraUpVector, vector));
+            var vector3 = Vector3.Cross(vector, vector2);
+		    result.M11 = vector2.X;
+		    result.M12 = vector3.X;
+		    result.M13 = vector.X;
+		    result.M14 = 0f;
+		    result.M21 = vector2.Y;
+		    result.M22 = vector3.Y;
+		    result.M23 = vector.Y;
+		    result.M24 = 0f;
+		    result.M31 = vector2.Z;
+		    result.M32 = vector3.Z;
+		    result.M33 = vector.Z;
+		    result.M34 = 0f;
+		    result.M41 = -Vector3.Dot(vector2, cameraPosition);
+		    result.M42 = -Vector3.Dot(vector3, cameraPosition);
+		    result.M43 = -Vector3.Dot(vector, cameraPosition);
+		    result.M44 = 1f;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for orthographic view.
+        /// </summary>
+        /// <param name="width">Width of the viewing volume.</param>
+        /// <param name="height">Height of the viewing volume.</param>
+        /// <param name="zNearPlane">Depth of the near plane.</param>
+        /// <param name="zFarPlane">Depth of the far plane.</param>
+        /// <returns>The new projection <see cref="Matrix4"/> for orthographic view.</returns>
+        public static Matrix4 CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane)
+        {
+            Matrix4 matrix;
+            CreateOrthographic(width, height, zNearPlane, zFarPlane, out matrix);
+		    return matrix;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for orthographic view.
+        /// </summary>
+        /// <param name="width">Width of the viewing volume.</param>
+        /// <param name="height">Height of the viewing volume.</param>
+        /// <param name="zNearPlane">Depth of the near plane.</param>
+        /// <param name="zFarPlane">Depth of the far plane.</param>
+        /// <param name="result">The new projection <see cref="Matrix4"/> for orthographic view as an output parameter.</param>
+        public static void CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane, out Matrix4 result)
+        {
+            result.M11 = 2f / width;
+		    result.M12 = result.M13 = result.M14 = 0f;
+		    result.M22 = 2f / height;
+		    result.M21 = result.M23 = result.M24 = 0f;
+		    result.M33 = 1f / (zNearPlane - zFarPlane);
+		    result.M31 = result.M32 = result.M34 = 0f;
+		    result.M41 = result.M42 = 0f;
+		    result.M43 = zNearPlane / (zNearPlane - zFarPlane);
+		    result.M44 = 1f;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for customized orthographic view.
+        /// </summary>
+        /// <param name="left">Lower x-value at the near plane.</param>
+        /// <param name="right">Upper x-value at the near plane.</param>
+        /// <param name="bottom">Lower y-coordinate at the near plane.</param>
+        /// <param name="top">Upper y-value at the near plane.</param>
+        /// <param name="zNearPlane">Depth of the near plane.</param>
+        /// <param name="zFarPlane">Depth of the far plane.</param>
+        /// <returns>The new projection <see cref="Matrix4"/> for customized orthographic view.</returns>
+        public static Matrix4 CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
+        {
+			Matrix4 matrix;
+            CreateOrthographicOffCenter(left, right, bottom, top, zNearPlane, zFarPlane, out matrix);
+			return matrix;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for customized orthographic view.
+        /// </summary>
+        /// <param name="left">Lower x-value at the near plane.</param>
+        /// <param name="right">Upper x-value at the near plane.</param>
+        /// <param name="bottom">Lower y-coordinate at the near plane.</param>
+        /// <param name="top">Upper y-value at the near plane.</param>
+        /// <param name="zNearPlane">Depth of the near plane.</param>
+        /// <param name="zFarPlane">Depth of the far plane.</param>
+        /// <param name="result">The new projection <see cref="Matrix4"/> for customized orthographic view as an output parameter.</param>
+        public static void CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane, out Matrix4 result)
+        {
+			result.M11 = (float)(2.0 / ((double)right - (double)left));
+			result.M12 = 0.0f;
+			result.M13 = 0.0f;
+			result.M14 = 0.0f;
+			result.M21 = 0.0f;
+			result.M22 = (float)(2.0 / ((double)top - (double)bottom));
+			result.M23 = 0.0f;
+			result.M24 = 0.0f;
+			result.M31 = 0.0f;
+			result.M32 = 0.0f;
+			result.M33 = (float)(1.0 / ((double)zNearPlane - (double)zFarPlane));
+			result.M34 = 0.0f;
+			result.M41 = (float)(((double)left + (double)right) / ((double)left - (double)right));
+			result.M42 = (float)(((double)top + (double)bottom) / ((double)bottom - (double)top));
+			result.M43 = (float)((double)zNearPlane / ((double)zNearPlane - (double)zFarPlane));
+			result.M44 = 1.0f;
+		}
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for perspective view.
+        /// </summary>
+        /// <param name="width">Width of the viewing volume.</param>
+        /// <param name="height">Height of the viewing volume.</param>
+        /// <param name="nearPlaneDistance">Distance to the near plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <returns>The new projection <see cref="Matrix4"/> for perspective view.</returns>
+        public static Matrix4 CreatePerspective(float width, float height, float nearPlaneDistance, float farPlaneDistance)
+        {
+            Matrix4 matrix;
+            CreatePerspective(width, height, nearPlaneDistance, farPlaneDistance, out matrix);
+		    return matrix;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for perspective view.
+        /// </summary>
+        /// <param name="width">Width of the viewing volume.</param>
+        /// <param name="height">Height of the viewing volume.</param>
+        /// <param name="nearPlaneDistance">Distance to the near plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <param name="result">The new projection <see cref="Matrix4"/> for perspective view as an output parameter.</param>
+        public static void CreatePerspective(float width, float height, float nearPlaneDistance, float farPlaneDistance, out Matrix4 result)
+        {
+            if (nearPlaneDistance <= 0f)
+		    {
+		        throw new ArgumentException("nearPlaneDistance <= 0");
+		    }
+		    if (farPlaneDistance <= 0f)
+		    {
+		        throw new ArgumentException("farPlaneDistance <= 0");
+		    }
+		    if (nearPlaneDistance >= farPlaneDistance)
+		    {
+		        throw new ArgumentException("nearPlaneDistance >= farPlaneDistance");
+		    }
+		    result.M11 = (2f * nearPlaneDistance) / width;
+		    result.M12 = result.M13 = result.M14 = 0f;
+		    result.M22 = (2f * nearPlaneDistance) / height;
+		    result.M21 = result.M23 = result.M24 = 0f;
+		    result.M33 = farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+		    result.M31 = result.M32 = 0f;
+		    result.M34 = -1f;
+		    result.M41 = result.M42 = result.M44 = 0f;
+		    result.M43 = (nearPlaneDistance * farPlaneDistance) / (nearPlaneDistance - farPlaneDistance);
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for perspective view with field of view.
+        /// </summary>
+        /// <param name="fieldOfView">Field of view in the y direction in radians.</param>
+        /// <param name="aspectRatio">Width divided by height of the viewing volume.</param>
+        /// <param name="nearPlaneDistance">Distance to the near plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <returns>The new projection <see cref="Matrix4"/> for perspective view with FOV.</returns>
+        public static Matrix4 CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance)
+        {
+            Matrix4 result;
+            CreatePerspectiveFieldOfView(fieldOfView, aspectRatio, nearPlaneDistance, farPlaneDistance, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for perspective view with field of view.
+        /// </summary>
+        /// <param name="fieldOfView">Field of view in the y direction in radians.</param>
+        /// <param name="aspectRatio">Width divided by height of the viewing volume.</param>
+        /// <param name="nearPlaneDistance">Distance of the near plane.</param>
+        /// <param name="farPlaneDistance">Distance of the far plane.</param>
+        /// <param name="result">The new projection <see cref="Matrix4"/> for perspective view with FOV as an output parameter.</param>
+        public static void CreatePerspectiveFieldOfView(float fieldOfView, float aspectRatio, float nearPlaneDistance, float farPlaneDistance, out Matrix4 result)
+        {
+            if ((fieldOfView <= 0f) || (fieldOfView >= 3.141593f))
+		    {
+		        throw new ArgumentException("fieldOfView <= 0 or >= PI");
+		    }
+		    if (nearPlaneDistance <= 0f)
+		    {
+		        throw new ArgumentException("nearPlaneDistance <= 0");
+		    }
+		    if (farPlaneDistance <= 0f)
+		    {
+		        throw new ArgumentException("farPlaneDistance <= 0");
+		    }
+		    if (nearPlaneDistance >= farPlaneDistance)
+		    {
+		        throw new ArgumentException("nearPlaneDistance >= farPlaneDistance");
+		    }
+		    float num = 1f / ((float) Math.Tan((double) (fieldOfView * 0.5f)));
+		    float num9 = num / aspectRatio;
+		    result.M11 = num9;
+		    result.M12 = result.M13 = result.M14 = 0;
+		    result.M22 = num;
+		    result.M21 = result.M23 = result.M24 = 0;
+		    result.M31 = result.M32 = 0f;
+		    result.M33 = farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+		    result.M34 = -1;
+		    result.M41 = result.M42 = result.M44 = 0;
+		    result.M43 = (nearPlaneDistance * farPlaneDistance) / (nearPlaneDistance - farPlaneDistance);
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for customized perspective view.
+        /// </summary>
+        /// <param name="left">Lower x-value at the near plane.</param>
+        /// <param name="right">Upper x-value at the near plane.</param>
+        /// <param name="bottom">Lower y-coordinate at the near plane.</param>
+        /// <param name="top">Upper y-value at the near plane.</param>
+        /// <param name="nearPlaneDistance">Distance to the near plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <returns>The new <see cref="Matrix4"/> for customized perspective view.</returns>
+        public static Matrix4 CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlaneDistance, float farPlaneDistance)
+        {
+            Matrix4 result;
+            CreatePerspectiveOffCenter(left, right, bottom, top, nearPlaneDistance, farPlaneDistance, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new projection <see cref="Matrix4"/> for customized perspective view.
+        /// </summary>
+        /// <param name="left">Lower x-value at the near plane.</param>
+        /// <param name="right">Upper x-value at the near plane.</param>
+        /// <param name="bottom">Lower y-coordinate at the near plane.</param>
+        /// <param name="top">Upper y-value at the near plane.</param>
+        /// <param name="nearPlaneDistance">Distance to the near plane.</param>
+        /// <param name="farPlaneDistance">Distance to the far plane.</param>
+        /// <param name="result">The new <see cref="Matrix4"/> for customized perspective view as an output parameter.</param>
+        public static void CreatePerspectiveOffCenter(float left, float right, float bottom, float top, float nearPlaneDistance, float farPlaneDistance, out Matrix4 result)
+        {
+            if (nearPlaneDistance <= 0f)
+		    {
+		        throw new ArgumentException("nearPlaneDistance <= 0");
+		    }
+		    if (farPlaneDistance <= 0f)
+		    {
+		        throw new ArgumentException("farPlaneDistance <= 0");
+		    }
+		    if (nearPlaneDistance >= farPlaneDistance)
+		    {
+		        throw new ArgumentException("nearPlaneDistance >= farPlaneDistance");
+		    }
+		    result.M11 = (2f * nearPlaneDistance) / (right - left);
+		    result.M12 = result.M13 = result.M14 = 0;
+		    result.M22 = (2f * nearPlaneDistance) / (top - bottom);
+		    result.M21 = result.M23 = result.M24 = 0;
+		    result.M31 = (left + right) / (right - left);
+		    result.M32 = (top + bottom) / (top - bottom);
+		    result.M33 = farPlaneDistance / (nearPlaneDistance - farPlaneDistance);
+		    result.M34 = -1;
+		    result.M43 = (nearPlaneDistance * farPlaneDistance) / (nearPlaneDistance - farPlaneDistance);
+		    result.M41 = result.M42 = result.M44 = 0;
+        }
+
+        /// <summary>
+        /// Creates a new rotation <see cref="Matrix4"/> around X axis.
+        /// </summary>
+        /// <param name="radians">Angle in radians.</param>
+        /// <returns>The rotation <see cref="Matrix4"/> around X axis.</returns>
+        public static Matrix4 CreateRotationX(float radians)
+        {
+            Matrix4 result;
+            CreateRotationX(radians, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new rotation <see cref="Matrix4"/> around X axis.
+        /// </summary>
+        /// <param name="radians">Angle in radians.</param>
+        /// <param name="result">The rotation <see cref="Matrix4"/> around X axis as an output parameter.</param>
+        public static void CreateRotationX(float radians, out Matrix4 result)
+        {
+            result = Matrix4.Identity;
+
+			var val1 = (float)Math.Cos(radians);
+			var val2 = (float)Math.Sin(radians);
+			
+            result.M22 = val1;
+            result.M23 = val2;
+            result.M32 = -val2;
+            result.M33 = val1;
+        }
+
+        /// <summary>
+        /// Creates a new rotation <see cref="Matrix4"/> around Y axis.
+        /// </summary>
+        /// <param name="radians">Angle in radians.</param>
+        /// <returns>The rotation <see cref="Matrix4"/> around Y axis.</returns>
+        public static Matrix4 CreateRotationY(float radians)
+        {
+            Matrix4 result;
+            CreateRotationY(radians, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new rotation <see cref="Matrix4"/> around Y axis.
+        /// </summary>
+        /// <param name="radians">Angle in radians.</param>
+        /// <param name="result">The rotation <see cref="Matrix4"/> around Y axis as an output parameter.</param>
+        public static void CreateRotationY(float radians, out Matrix4 result)
+        {
+            result = Matrix4.Identity;
+
+            var val1 = (float)Math.Cos(radians);
+			var val2 = (float)Math.Sin(radians);
+			
+            result.M11 = val1;
+            result.M13 = -val2;
+            result.M31 = val2;
+            result.M33 = val1;
+        }
+
+        /// <summary>
+        /// Creates a new rotation <see cref="Matrix4"/> around Z axis.
+        /// </summary>
+        /// <param name="radians">Angle in radians.</param>
+        /// <returns>The rotation <see cref="Matrix4"/> around Z axis.</returns>
+        public static Matrix4 CreateRotationZ(float radians)
+        {
+            Matrix4 result;
+            CreateRotationZ(radians, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new rotation <see cref="Matrix4"/> around Z axis.
+        /// </summary>
+        /// <param name="radians">Angle in radians.</param>
+        /// <param name="result">The rotation <see cref="Matrix4"/> around Z axis as an output parameter.</param>
+        public static void CreateRotationZ(float radians, out Matrix4 result)
+        {
+            result = Matrix4.Identity;
+
+			var val1 = (float)Math.Cos(radians);
+			var val2 = (float)Math.Sin(radians);
+			
+            result.M11 = val1;
+            result.M12 = val2;
+            result.M21 = -val2;
+            result.M22 = val1;
+        }
+
+        /// <summary>
+        /// Creates a new scaling <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="scale">Scale value for all three axises.</param>
+        /// <returns>The scaling <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateScale(float scale)
+        {
+            Matrix4 result;
+            CreateScale(scale, scale, scale, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new scaling <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="scale">Scale value for all three axises.</param>
+        /// <param name="result">The scaling <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateScale(float scale, out Matrix4 result)
+        {
+            CreateScale(scale, scale, scale, out result);
+        }
+
+        /// <summary>
+        /// Creates a new scaling <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="xScale">Scale value for X axis.</param>
+        /// <param name="yScale">Scale value for Y axis.</param>
+        /// <param name="zScale">Scale value for Z axis.</param>
+        /// <returns>The scaling <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateScale(float xScale, float yScale, float zScale)
+        {
+            Matrix4 result;
+            CreateScale(xScale, yScale, zScale, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new scaling <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="xScale">Scale value for X axis.</param>
+        /// <param name="yScale">Scale value for Y axis.</param>
+        /// <param name="zScale">Scale value for Z axis.</param>
+        /// <param name="result">The scaling <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateScale(float xScale, float yScale, float zScale, out Matrix4 result)
+        {
+			result.M11 = xScale;
+			result.M12 = 0;
+			result.M13 = 0;
+			result.M14 = 0;
+			result.M21 = 0;
+			result.M22 = yScale;
+			result.M23 = 0;
+			result.M24 = 0;
+			result.M31 = 0;
+			result.M32 = 0;
+			result.M33 = zScale;
+			result.M34 = 0;
+			result.M41 = 0;
+			result.M42 = 0;
+			result.M43 = 0;
+			result.M44 = 1;
+        }
+
+        /// <summary>
+        /// Creates a new scaling <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="scales"><see cref="Vector3"/> representing x,y and z scale values.</param>
+        /// <returns>The scaling <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateScale(Vector3 scales)
+        {
+            Matrix4 result;
+            CreateScale(ref scales, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new scaling <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="scales"><see cref="Vector3"/> representing x,y and z scale values.</param>
+        /// <param name="result">The scaling <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateScale(ref Vector3 scales, out Matrix4 result)
+        {
+            result.M11 = scales.X;
+            result.M12 = 0;
+            result.M13 = 0;
+            result.M14 = 0;
+            result.M21 = 0;
+            result.M22 = scales.Y;
+            result.M23 = 0;
+            result.M24 = 0;
+            result.M31 = 0;
+            result.M32 = 0;
+            result.M33 = scales.Z;
+            result.M34 = 0;
+            result.M41 = 0;
+            result.M42 = 0;
+            result.M43 = 0;
+            result.M44 = 1;
+        }
+
+     
+        /// <summary>
+        /// Creates a new translation <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="xPosition">X coordinate of translation.</param>
+        /// <param name="yPosition">Y coordinate of translation.</param>
+        /// <param name="zPosition">Z coordinate of translation.</param>
+        /// <returns>The translation <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateTranslation(float xPosition, float yPosition, float zPosition)
+        {
+            Matrix4 result;
+            CreateTranslation(xPosition, yPosition, zPosition, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new translation <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="position">X,Y and Z coordinates of translation.</param>
+        /// <param name="result">The translation <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateTranslation(ref Vector3 position, out Matrix4 result)
+        {
+            result.M11 = 1;
+            result.M12 = 0;
+            result.M13 = 0;
+            result.M14 = 0;
+            result.M21 = 0;
+            result.M22 = 1;
+            result.M23 = 0;
+            result.M24 = 0;
+            result.M31 = 0;
+            result.M32 = 0;
+            result.M33 = 1;
+            result.M34 = 0;
+            result.M41 = position.X;
+            result.M42 = position.Y;
+            result.M43 = position.Z;
+            result.M44 = 1;
+        }
+
+        /// <summary>
+        /// Creates a new translation <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="position">X,Y and Z coordinates of translation.</param>
+        /// <returns>The translation <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateTranslation(Vector3 position)
+        {
+			Matrix4 result;
+            CreateTranslation(ref position, out result);
+			return result;
+        }
+
+        /// <summary>
+        /// Creates a new translation <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="xPosition">X coordinate of translation.</param>
+        /// <param name="yPosition">Y coordinate of translation.</param>
+        /// <param name="zPosition">Z coordinate of translation.</param>
+        /// <param name="result">The translation <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateTranslation(float xPosition, float yPosition, float zPosition, out Matrix4 result)
+        {
+            result.M11 = 1;
+			result.M12 = 0;
+			result.M13 = 0;
+			result.M14 = 0;
+			result.M21 = 0;
+			result.M22 = 1;
+			result.M23 = 0;
+			result.M24 = 0;
+			result.M31 = 0;
+			result.M32 = 0;
+			result.M33 = 1;
+			result.M34 = 0;
+			result.M41 = xPosition;
+			result.M42 = yPosition;
+			result.M43 = zPosition;
+			result.M44 = 1;
+        }
+        
+        /// <summary>
+        /// Creates a new world <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="position">The position vector.</param>
+        /// <param name="forward">The forward direction vector.</param>
+        /// <param name="up">The upward direction vector. Usually <see cref="Vector3.Up"/>.</param>
+        /// <returns>The world <see cref="Matrix4"/>.</returns>
+        public static Matrix4 CreateWorld(Vector3 position, Vector3 forward, Vector3 up)
+        {
+            Matrix4 ret;
+                        CreateWorld(ref position, ref forward, ref up, out ret);
+                        return ret;
+        }
+
+        /// <summary>
+        /// Creates a new world <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="position">The position vector.</param>
+        /// <param name="forward">The forward direction vector.</param>
+        /// <param name="up">The upward direction vector. Usually <see cref="Vector3.Up"/>.</param>
+        /// <param name="result">The world <see cref="Matrix4"/> as an output parameter.</param>
+        public static void CreateWorld(ref Vector3 position, ref Vector3 forward, ref Vector3 up, out Matrix4 result)
+        {
+                        Vector3 x, y, z;
+                        Vector3.Normalize(ref forward, out z);
+                        Vector3.Cross(ref forward, ref up, out x);
+                        Vector3.Cross(ref x, ref forward, out y);
+                        x.Normalize();
+                        y.Normalize();            
+                        
+                        result = new Matrix4();
+                        result.Right = x;
+                        result.Up = y;
+                        result.Forward = z;
+                        result.Translation = position;
+                        result.M44 = 1f;
+        }
+
+		/// <summary>
+        /// Returns a determinant of this <see cref="Matrix4"/>.
+        /// </summary>
+        /// <returns>Determinant of this <see cref="Matrix4"/></returns>
+        /// <remarks>See more about determinant here - http://en.wikipedia.org/wiki/Determinant.
+        /// </remarks>
+        public float Determinant()
+        {
+            float num22 = this.M11;
+		    float num21 = this.M12;
+		    float num20 = this.M13;
+		    float num19 = this.M14;
+		    float num12 = this.M21;
+		    float num11 = this.M22;
+		    float num10 = this.M23;
+		    float num9 = this.M24;
+		    float num8 = this.M31;
+		    float num7 = this.M32;
+		    float num6 = this.M33;
+		    float num5 = this.M34;
+		    float num4 = this.M41;
+		    float num3 = this.M42;
+		    float num2 = this.M43;
+		    float num = this.M44;
+		    float num18 = (num6 * num) - (num5 * num2);
+		    float num17 = (num7 * num) - (num5 * num3);
+		    float num16 = (num7 * num2) - (num6 * num3);
+		    float num15 = (num8 * num) - (num5 * num4);
+		    float num14 = (num8 * num2) - (num6 * num4);
+		    float num13 = (num8 * num3) - (num7 * num4);
+		    return ((((num22 * (((num11 * num18) - (num10 * num17)) + (num9 * num16))) - (num21 * (((num12 * num18) - (num10 * num15)) + (num9 * num14)))) + (num20 * (((num12 * num17) - (num11 * num15)) + (num9 * num13)))) - (num19 * (((num12 * num16) - (num11 * num14)) + (num10 * num13))));
+        }
+
+        /// <summary>
+        /// Divides the elements of a <see cref="Matrix4"/> by the elements of another matrix.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">Divisor <see cref="Matrix4"/>.</param>
+        /// <returns>The result of dividing the matrix.</returns>
+        public static Matrix4 Divide(Matrix4 matrix1, Matrix4 matrix2)
+        {
+		    matrix1.M11 = matrix1.M11 / matrix2.M11;
+		    matrix1.M12 = matrix1.M12 / matrix2.M12;
+		    matrix1.M13 = matrix1.M13 / matrix2.M13;
+		    matrix1.M14 = matrix1.M14 / matrix2.M14;
+		    matrix1.M21 = matrix1.M21 / matrix2.M21;
+		    matrix1.M22 = matrix1.M22 / matrix2.M22;
+		    matrix1.M23 = matrix1.M23 / matrix2.M23;
+		    matrix1.M24 = matrix1.M24 / matrix2.M24;
+		    matrix1.M31 = matrix1.M31 / matrix2.M31;
+		    matrix1.M32 = matrix1.M32 / matrix2.M32;
+		    matrix1.M33 = matrix1.M33 / matrix2.M33;
+		    matrix1.M34 = matrix1.M34 / matrix2.M34;
+		    matrix1.M41 = matrix1.M41 / matrix2.M41;
+		    matrix1.M42 = matrix1.M42 / matrix2.M42;
+		    matrix1.M43 = matrix1.M43 / matrix2.M43;
+		    matrix1.M44 = matrix1.M44 / matrix2.M44;
+		    return matrix1;
+        }
+
+        /// <summary>
+        /// Divides the elements of a <see cref="Matrix4"/> by the elements of another matrix.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">Divisor <see cref="Matrix4"/>.</param>
+        /// <param name="result">The result of dividing the matrix as an output parameter.</param>
+        public static void Divide(ref Matrix4 matrix1, ref Matrix4 matrix2, out Matrix4 result)
+        {
+            result.M11 = matrix1.M11 / matrix2.M11;
+		    result.M12 = matrix1.M12 / matrix2.M12;
+		    result.M13 = matrix1.M13 / matrix2.M13;
+		    result.M14 = matrix1.M14 / matrix2.M14;
+		    result.M21 = matrix1.M21 / matrix2.M21;
+		    result.M22 = matrix1.M22 / matrix2.M22;
+		    result.M23 = matrix1.M23 / matrix2.M23;
+		    result.M24 = matrix1.M24 / matrix2.M24;
+		    result.M31 = matrix1.M31 / matrix2.M31;
+		    result.M32 = matrix1.M32 / matrix2.M32;
+		    result.M33 = matrix1.M33 / matrix2.M33;
+		    result.M34 = matrix1.M34 / matrix2.M34;
+		    result.M41 = matrix1.M41 / matrix2.M41;
+		    result.M42 = matrix1.M42 / matrix2.M42;
+		    result.M43 = matrix1.M43 / matrix2.M43;
+		    result.M44 = matrix1.M44 / matrix2.M44;
+        }
+
+        /// <summary>
+        /// Divides the elements of a <see cref="Matrix4"/> by a scalar.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="divider">Divisor scalar.</param>
+        /// <returns>The result of dividing a matrix by a scalar.</returns>
+        public static Matrix4 Divide(Matrix4 matrix1, float divider)
+        {
+		    float num = 1f / divider;
+		    matrix1.M11 = matrix1.M11 * num;
+		    matrix1.M12 = matrix1.M12 * num;
+		    matrix1.M13 = matrix1.M13 * num;
+		    matrix1.M14 = matrix1.M14 * num;
+		    matrix1.M21 = matrix1.M21 * num;
+		    matrix1.M22 = matrix1.M22 * num;
+		    matrix1.M23 = matrix1.M23 * num;
+		    matrix1.M24 = matrix1.M24 * num;
+		    matrix1.M31 = matrix1.M31 * num;
+		    matrix1.M32 = matrix1.M32 * num;
+		    matrix1.M33 = matrix1.M33 * num;
+		    matrix1.M34 = matrix1.M34 * num;
+		    matrix1.M41 = matrix1.M41 * num;
+		    matrix1.M42 = matrix1.M42 * num;
+		    matrix1.M43 = matrix1.M43 * num;
+		    matrix1.M44 = matrix1.M44 * num;
+		    return matrix1;
+        }
+
+        /// <summary>
+        /// Divides the elements of a <see cref="Matrix4"/> by a scalar.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="divider">Divisor scalar.</param>
+        /// <param name="result">The result of dividing a matrix by a scalar as an output parameter.</param>
+        public static void Divide(ref Matrix4 matrix1, float divider, out Matrix4 result)
+        {
+            float num = 1f / divider;
+		    result.M11 = matrix1.M11 * num;
+		    result.M12 = matrix1.M12 * num;
+		    result.M13 = matrix1.M13 * num;
+		    result.M14 = matrix1.M14 * num;
+		    result.M21 = matrix1.M21 * num;
+		    result.M22 = matrix1.M22 * num;
+		    result.M23 = matrix1.M23 * num;
+		    result.M24 = matrix1.M24 * num;
+		    result.M31 = matrix1.M31 * num;
+		    result.M32 = matrix1.M32 * num;
+		    result.M33 = matrix1.M33 * num;
+		    result.M34 = matrix1.M34 * num;
+		    result.M41 = matrix1.M41 * num;
+		    result.M42 = matrix1.M42 * num;
+		    result.M43 = matrix1.M43 * num;
+		    result.M44 = matrix1.M44 * num;
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Matrix4"/> without any tolerance.
+        /// </summary>
+        /// <param name="other">The <see cref="Matrix4"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public bool Equals(Matrix4 other)
+        {
+            return ((((((this.M11 == other.M11) && (this.M22 == other.M22)) && ((this.M33 == other.M33) && (this.M44 == other.M44))) && (((this.M12 == other.M12) && (this.M13 == other.M13)) && ((this.M14 == other.M14) && (this.M21 == other.M21)))) && ((((this.M23 == other.M23) && (this.M24 == other.M24)) && ((this.M31 == other.M31) && (this.M32 == other.M32))) && (((this.M34 == other.M34) && (this.M41 == other.M41)) && (this.M42 == other.M42)))) && (this.M43 == other.M43));
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Object"/> without any tolerance.
+        /// </summary>
+        /// <param name="obj">The <see cref="Object"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            bool flag = false;
+		    if (obj is Matrix4)
+		    {
+		        flag = this.Equals((Matrix4) obj);
+		    }
+		    return flag;
+        }
+
+        /// <summary>
+        /// Gets the hash code of this <see cref="Matrix4"/>.
+        /// </summary>
+        /// <returns>Hash code of this <see cref="Matrix4"/>.</returns>
+        public override int GetHashCode()
+        {
+            return (((((((((((((((this.M11.GetHashCode() + this.M12.GetHashCode()) + this.M13.GetHashCode()) + this.M14.GetHashCode()) + this.M21.GetHashCode()) + this.M22.GetHashCode()) + this.M23.GetHashCode()) + this.M24.GetHashCode()) + this.M31.GetHashCode()) + this.M32.GetHashCode()) + this.M33.GetHashCode()) + this.M34.GetHashCode()) + this.M41.GetHashCode()) + this.M42.GetHashCode()) + this.M43.GetHashCode()) + this.M44.GetHashCode());
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> which contains inversion of the specified matrix. 
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/>.</param>
+        /// <returns>The inverted matrix.</returns>
+        public static Matrix4 Invert(Matrix4 matrix)
+        {
+            Invert(ref matrix, out matrix);
+            return matrix;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> which contains inversion of the specified matrix. 
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/>.</param>
+        /// <param name="result">The inverted matrix as output parameter.</param>
+        public static void Invert(ref Matrix4 matrix, out Matrix4 result)
+        {
+			float num1 = matrix.M11;
+			float num2 = matrix.M12;
+			float num3 = matrix.M13;
+			float num4 = matrix.M14;
+			float num5 = matrix.M21;
+			float num6 = matrix.M22;
+			float num7 = matrix.M23;
+			float num8 = matrix.M24;
+			float num9 = matrix.M31;
+			float num10 = matrix.M32;
+			float num11 = matrix.M33;
+			float num12 = matrix.M34;
+			float num13 = matrix.M41;
+			float num14 = matrix.M42;
+			float num15 = matrix.M43;
+			float num16 = matrix.M44;
+			float num17 = (float) ((double) num11 * (double) num16 - (double) num12 * (double) num15);
+			float num18 = (float) ((double) num10 * (double) num16 - (double) num12 * (double) num14);
+			float num19 = (float) ((double) num10 * (double) num15 - (double) num11 * (double) num14);
+			float num20 = (float) ((double) num9 * (double) num16 - (double) num12 * (double) num13);
+			float num21 = (float) ((double) num9 * (double) num15 - (double) num11 * (double) num13);
+			float num22 = (float) ((double) num9 * (double) num14 - (double) num10 * (double) num13);
+			float num23 = (float) ((double) num6 * (double) num17 - (double) num7 * (double) num18 + (double) num8 * (double) num19);
+			float num24 = (float) -((double) num5 * (double) num17 - (double) num7 * (double) num20 + (double) num8 * (double) num21);
+			float num25 = (float) ((double) num5 * (double) num18 - (double) num6 * (double) num20 + (double) num8 * (double) num22);
+			float num26 = (float) -((double) num5 * (double) num19 - (double) num6 * (double) num21 + (double) num7 * (double) num22);
+			float num27 = (float) (1.0 / ((double) num1 * (double) num23 + (double) num2 * (double) num24 + (double) num3 * (double) num25 + (double) num4 * (double) num26));
+			
+			result.M11 = num23 * num27;
+			result.M21 = num24 * num27;
+			result.M31 = num25 * num27;
+			result.M41 = num26 * num27;
+			result.M12 = (float) -((double) num2 * (double) num17 - (double) num3 * (double) num18 + (double) num4 * (double) num19) * num27;
+			result.M22 = (float) ((double) num1 * (double) num17 - (double) num3 * (double) num20 + (double) num4 * (double) num21) * num27;
+			result.M32 = (float) -((double) num1 * (double) num18 - (double) num2 * (double) num20 + (double) num4 * (double) num22) * num27;
+			result.M42 = (float) ((double) num1 * (double) num19 - (double) num2 * (double) num21 + (double) num3 * (double) num22) * num27;
+			float num28 = (float) ((double) num7 * (double) num16 - (double) num8 * (double) num15);
+			float num29 = (float) ((double) num6 * (double) num16 - (double) num8 * (double) num14);
+			float num30 = (float) ((double) num6 * (double) num15 - (double) num7 * (double) num14);
+			float num31 = (float) ((double) num5 * (double) num16 - (double) num8 * (double) num13);
+			float num32 = (float) ((double) num5 * (double) num15 - (double) num7 * (double) num13);
+			float num33 = (float) ((double) num5 * (double) num14 - (double) num6 * (double) num13);
+			result.M13 = (float) ((double) num2 * (double) num28 - (double) num3 * (double) num29 + (double) num4 * (double) num30) * num27;
+			result.M23 = (float) -((double) num1 * (double) num28 - (double) num3 * (double) num31 + (double) num4 * (double) num32) * num27;
+			result.M33 = (float) ((double) num1 * (double) num29 - (double) num2 * (double) num31 + (double) num4 * (double) num33) * num27;
+			result.M43 = (float) -((double) num1 * (double) num30 - (double) num2 * (double) num32 + (double) num3 * (double) num33) * num27;
+			float num34 = (float) ((double) num7 * (double) num12 - (double) num8 * (double) num11);
+			float num35 = (float) ((double) num6 * (double) num12 - (double) num8 * (double) num10);
+			float num36 = (float) ((double) num6 * (double) num11 - (double) num7 * (double) num10);
+			float num37 = (float) ((double) num5 * (double) num12 - (double) num8 * (double) num9);
+			float num38 = (float) ((double) num5 * (double) num11 - (double) num7 * (double) num9);
+			float num39 = (float) ((double) num5 * (double) num10 - (double) num6 * (double) num9);
+			result.M14 = (float) -((double) num2 * (double) num34 - (double) num3 * (double) num35 + (double) num4 * (double) num36) * num27;
+			result.M24 = (float) ((double) num1 * (double) num34 - (double) num3 * (double) num37 + (double) num4 * (double) num38) * num27;
+			result.M34 = (float) -((double) num1 * (double) num35 - (double) num2 * (double) num37 + (double) num4 * (double) num39) * num27;
+			result.M44 = (float) ((double) num1 * (double) num36 - (double) num2 * (double) num38 + (double) num3 * (double) num39) * num27;
+			
+			
+			/*
+			
+			
+            ///
+            // Use Laplace expansion theorem to calculate the inverse of a 4x4 matrix
+            // 
+            // 1. Calculate the 2x2 determinants needed the 4x4 determinant based on the 2x2 determinants 
+            // 3. Create the adjugate matrix, which satisfies: A * adj(A) = det(A) * I
+            // 4. Divide adjugate matrix with the determinant to find the inverse
+            
+            float det1, det2, det3, det4, det5, det6, det7, det8, det9, det10, det11, det12;
+            float detMatrix;
+            FindDeterminants(ref matrix, out detMatrix, out det1, out det2, out det3, out det4, out det5, out det6, 
+                             out det7, out det8, out det9, out det10, out det11, out det12);
+            
+            float invDetMatrix = 1f / detMatrix;
+            
+            Matrix ret; // Allow for matrix and result to point to the same structure
+            
+            ret.M11 = (matrix.M22*det12 - matrix.M23*det11 + matrix.M24*det10) * invDetMatrix;
+            ret.M12 = (-matrix.M12*det12 + matrix.M13*det11 - matrix.M14*det10) * invDetMatrix;
+            ret.M13 = (matrix.M42*det6 - matrix.M43*det5 + matrix.M44*det4) * invDetMatrix;
+            ret.M14 = (-matrix.M32*det6 + matrix.M33*det5 - matrix.M34*det4) * invDetMatrix;
+            ret.M21 = (-matrix.M21*det12 + matrix.M23*det9 - matrix.M24*det8) * invDetMatrix;
+            ret.M22 = (matrix.M11*det12 - matrix.M13*det9 + matrix.M14*det8) * invDetMatrix;
+            ret.M23 = (-matrix.M41*det6 + matrix.M43*det3 - matrix.M44*det2) * invDetMatrix;
+            ret.M24 = (matrix.M31*det6 - matrix.M33*det3 + matrix.M34*det2) * invDetMatrix;
+            ret.M31 = (matrix.M21*det11 - matrix.M22*det9 + matrix.M24*det7) * invDetMatrix;
+            ret.M32 = (-matrix.M11*det11 + matrix.M12*det9 - matrix.M14*det7) * invDetMatrix;
+            ret.M33 = (matrix.M41*det5 - matrix.M42*det3 + matrix.M44*det1) * invDetMatrix;
+            ret.M34 = (-matrix.M31*det5 + matrix.M32*det3 - matrix.M34*det1) * invDetMatrix;
+            ret.M41 = (-matrix.M21*det10 + matrix.M22*det8 - matrix.M23*det7) * invDetMatrix;
+            ret.M42 = (matrix.M11*det10 - matrix.M12*det8 + matrix.M13*det7) * invDetMatrix;
+            ret.M43 = (-matrix.M41*det4 + matrix.M42*det2 - matrix.M43*det1) * invDetMatrix;
+            ret.M44 = (matrix.M31*det4 - matrix.M32*det2 + matrix.M33*det1) * invDetMatrix;
+            
+            result = ret;
+            */
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains linear interpolation of the values in specified matrixes.
+        /// </summary>
+        /// <param name="matrix1">The first <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">The second <see cref="Vector2"/>.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <returns>>The result of linear interpolation of the specified matrixes.</returns>
+        public static Matrix4 Lerp(Matrix4 matrix1, Matrix4 matrix2, float amount)
+        {
+		    matrix1.M11 = matrix1.M11 + ((matrix2.M11 - matrix1.M11) * amount);
+		    matrix1.M12 = matrix1.M12 + ((matrix2.M12 - matrix1.M12) * amount);
+		    matrix1.M13 = matrix1.M13 + ((matrix2.M13 - matrix1.M13) * amount);
+		    matrix1.M14 = matrix1.M14 + ((matrix2.M14 - matrix1.M14) * amount);
+		    matrix1.M21 = matrix1.M21 + ((matrix2.M21 - matrix1.M21) * amount);
+		    matrix1.M22 = matrix1.M22 + ((matrix2.M22 - matrix1.M22) * amount);
+		    matrix1.M23 = matrix1.M23 + ((matrix2.M23 - matrix1.M23) * amount);
+		    matrix1.M24 = matrix1.M24 + ((matrix2.M24 - matrix1.M24) * amount);
+		    matrix1.M31 = matrix1.M31 + ((matrix2.M31 - matrix1.M31) * amount);
+		    matrix1.M32 = matrix1.M32 + ((matrix2.M32 - matrix1.M32) * amount);
+		    matrix1.M33 = matrix1.M33 + ((matrix2.M33 - matrix1.M33) * amount);
+		    matrix1.M34 = matrix1.M34 + ((matrix2.M34 - matrix1.M34) * amount);
+		    matrix1.M41 = matrix1.M41 + ((matrix2.M41 - matrix1.M41) * amount);
+		    matrix1.M42 = matrix1.M42 + ((matrix2.M42 - matrix1.M42) * amount);
+		    matrix1.M43 = matrix1.M43 + ((matrix2.M43 - matrix1.M43) * amount);
+		    matrix1.M44 = matrix1.M44 + ((matrix2.M44 - matrix1.M44) * amount);
+		    return matrix1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains linear interpolation of the values in specified matrixes.
+        /// </summary>
+        /// <param name="matrix1">The first <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">The second <see cref="Vector2"/>.</param>
+        /// <param name="amount">Weighting value(between 0.0 and 1.0).</param>
+        /// <param name="result">The result of linear interpolation of the specified matrixes as an output parameter.</param>
+        public static void Lerp(ref Matrix4 matrix1, ref Matrix4 matrix2, float amount, out Matrix4 result)
+        {
+            result.M11 = matrix1.M11 + ((matrix2.M11 - matrix1.M11) * amount);
+		    result.M12 = matrix1.M12 + ((matrix2.M12 - matrix1.M12) * amount);
+		    result.M13 = matrix1.M13 + ((matrix2.M13 - matrix1.M13) * amount);
+		    result.M14 = matrix1.M14 + ((matrix2.M14 - matrix1.M14) * amount);
+		    result.M21 = matrix1.M21 + ((matrix2.M21 - matrix1.M21) * amount);
+		    result.M22 = matrix1.M22 + ((matrix2.M22 - matrix1.M22) * amount);
+		    result.M23 = matrix1.M23 + ((matrix2.M23 - matrix1.M23) * amount);
+		    result.M24 = matrix1.M24 + ((matrix2.M24 - matrix1.M24) * amount);
+		    result.M31 = matrix1.M31 + ((matrix2.M31 - matrix1.M31) * amount);
+		    result.M32 = matrix1.M32 + ((matrix2.M32 - matrix1.M32) * amount);
+		    result.M33 = matrix1.M33 + ((matrix2.M33 - matrix1.M33) * amount);
+		    result.M34 = matrix1.M34 + ((matrix2.M34 - matrix1.M34) * amount);
+		    result.M41 = matrix1.M41 + ((matrix2.M41 - matrix1.M41) * amount);
+		    result.M42 = matrix1.M42 + ((matrix2.M42 - matrix1.M42) * amount);
+		    result.M43 = matrix1.M43 + ((matrix2.M43 - matrix1.M43) * amount);
+		    result.M44 = matrix1.M44 + ((matrix2.M44 - matrix1.M44) * amount);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains a multiplication of two matrix.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/>.</param>
+        /// <returns>Result of the matrix multiplication.</returns>
+        public static Matrix4 Multiply(Matrix4 matrix1, Matrix4 matrix2)
+        {
+            var m11 = (((matrix1.M11 * matrix2.M11) + (matrix1.M12 * matrix2.M21)) + (matrix1.M13 * matrix2.M31)) + (matrix1.M14 * matrix2.M41);
+            var m12 = (((matrix1.M11 * matrix2.M12) + (matrix1.M12 * matrix2.M22)) + (matrix1.M13 * matrix2.M32)) + (matrix1.M14 * matrix2.M42);
+            var m13 = (((matrix1.M11 * matrix2.M13) + (matrix1.M12 * matrix2.M23)) + (matrix1.M13 * matrix2.M33)) + (matrix1.M14 * matrix2.M43);
+            var m14 = (((matrix1.M11 * matrix2.M14) + (matrix1.M12 * matrix2.M24)) + (matrix1.M13 * matrix2.M34)) + (matrix1.M14 * matrix2.M44);
+            var m21 = (((matrix1.M21 * matrix2.M11) + (matrix1.M22 * matrix2.M21)) + (matrix1.M23 * matrix2.M31)) + (matrix1.M24 * matrix2.M41);
+            var m22 = (((matrix1.M21 * matrix2.M12) + (matrix1.M22 * matrix2.M22)) + (matrix1.M23 * matrix2.M32)) + (matrix1.M24 * matrix2.M42);
+            var m23 = (((matrix1.M21 * matrix2.M13) + (matrix1.M22 * matrix2.M23)) + (matrix1.M23 * matrix2.M33)) + (matrix1.M24 * matrix2.M43);
+            var m24 = (((matrix1.M21 * matrix2.M14) + (matrix1.M22 * matrix2.M24)) + (matrix1.M23 * matrix2.M34)) + (matrix1.M24 * matrix2.M44);
+            var m31 = (((matrix1.M31 * matrix2.M11) + (matrix1.M32 * matrix2.M21)) + (matrix1.M33 * matrix2.M31)) + (matrix1.M34 * matrix2.M41);
+            var m32 = (((matrix1.M31 * matrix2.M12) + (matrix1.M32 * matrix2.M22)) + (matrix1.M33 * matrix2.M32)) + (matrix1.M34 * matrix2.M42);
+            var m33 = (((matrix1.M31 * matrix2.M13) + (matrix1.M32 * matrix2.M23)) + (matrix1.M33 * matrix2.M33)) + (matrix1.M34 * matrix2.M43);
+            var m34 = (((matrix1.M31 * matrix2.M14) + (matrix1.M32 * matrix2.M24)) + (matrix1.M33 * matrix2.M34)) + (matrix1.M34 * matrix2.M44);
+            var m41 = (((matrix1.M41 * matrix2.M11) + (matrix1.M42 * matrix2.M21)) + (matrix1.M43 * matrix2.M31)) + (matrix1.M44 * matrix2.M41);
+            var m42 = (((matrix1.M41 * matrix2.M12) + (matrix1.M42 * matrix2.M22)) + (matrix1.M43 * matrix2.M32)) + (matrix1.M44 * matrix2.M42);
+            var m43 = (((matrix1.M41 * matrix2.M13) + (matrix1.M42 * matrix2.M23)) + (matrix1.M43 * matrix2.M33)) + (matrix1.M44 * matrix2.M43);
+           	var m44 = (((matrix1.M41 * matrix2.M14) + (matrix1.M42 * matrix2.M24)) + (matrix1.M43 * matrix2.M34)) + (matrix1.M44 * matrix2.M44);
+            matrix1.M11 = m11;
+			matrix1.M12 = m12;
+			matrix1.M13 = m13;
+			matrix1.M14 = m14;
+			matrix1.M21 = m21;
+			matrix1.M22 = m22;
+			matrix1.M23 = m23;
+			matrix1.M24 = m24;
+			matrix1.M31 = m31;
+			matrix1.M32 = m32;
+			matrix1.M33 = m33;
+			matrix1.M34 = m34;
+			matrix1.M41 = m41;
+			matrix1.M42 = m42;
+			matrix1.M43 = m43;
+			matrix1.M44 = m44;
+			return matrix1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains a multiplication of two matrix.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/>.</param>
+        /// <param name="result">Result of the matrix multiplication as an output parameter.</param>
+        public static void Multiply(ref Matrix4 matrix1, ref Matrix4 matrix2, out Matrix4 result)
+        {
+            var m11 = (((matrix1.M11 * matrix2.M11) + (matrix1.M12 * matrix2.M21)) + (matrix1.M13 * matrix2.M31)) + (matrix1.M14 * matrix2.M41);
+            var m12 = (((matrix1.M11 * matrix2.M12) + (matrix1.M12 * matrix2.M22)) + (matrix1.M13 * matrix2.M32)) + (matrix1.M14 * matrix2.M42);
+            var m13 = (((matrix1.M11 * matrix2.M13) + (matrix1.M12 * matrix2.M23)) + (matrix1.M13 * matrix2.M33)) + (matrix1.M14 * matrix2.M43);
+            var m14 = (((matrix1.M11 * matrix2.M14) + (matrix1.M12 * matrix2.M24)) + (matrix1.M13 * matrix2.M34)) + (matrix1.M14 * matrix2.M44);
+            var m21 = (((matrix1.M21 * matrix2.M11) + (matrix1.M22 * matrix2.M21)) + (matrix1.M23 * matrix2.M31)) + (matrix1.M24 * matrix2.M41);
+            var m22 = (((matrix1.M21 * matrix2.M12) + (matrix1.M22 * matrix2.M22)) + (matrix1.M23 * matrix2.M32)) + (matrix1.M24 * matrix2.M42);
+            var m23 = (((matrix1.M21 * matrix2.M13) + (matrix1.M22 * matrix2.M23)) + (matrix1.M23 * matrix2.M33)) + (matrix1.M24 * matrix2.M43);
+            var m24 = (((matrix1.M21 * matrix2.M14) + (matrix1.M22 * matrix2.M24)) + (matrix1.M23 * matrix2.M34)) + (matrix1.M24 * matrix2.M44);
+            var m31 = (((matrix1.M31 * matrix2.M11) + (matrix1.M32 * matrix2.M21)) + (matrix1.M33 * matrix2.M31)) + (matrix1.M34 * matrix2.M41);
+            var m32 = (((matrix1.M31 * matrix2.M12) + (matrix1.M32 * matrix2.M22)) + (matrix1.M33 * matrix2.M32)) + (matrix1.M34 * matrix2.M42);
+            var m33 = (((matrix1.M31 * matrix2.M13) + (matrix1.M32 * matrix2.M23)) + (matrix1.M33 * matrix2.M33)) + (matrix1.M34 * matrix2.M43);
+            var m34 = (((matrix1.M31 * matrix2.M14) + (matrix1.M32 * matrix2.M24)) + (matrix1.M33 * matrix2.M34)) + (matrix1.M34 * matrix2.M44);
+            var m41 = (((matrix1.M41 * matrix2.M11) + (matrix1.M42 * matrix2.M21)) + (matrix1.M43 * matrix2.M31)) + (matrix1.M44 * matrix2.M41);
+            var m42 = (((matrix1.M41 * matrix2.M12) + (matrix1.M42 * matrix2.M22)) + (matrix1.M43 * matrix2.M32)) + (matrix1.M44 * matrix2.M42);
+            var m43 = (((matrix1.M41 * matrix2.M13) + (matrix1.M42 * matrix2.M23)) + (matrix1.M43 * matrix2.M33)) + (matrix1.M44 * matrix2.M43);
+           	var m44 = (((matrix1.M41 * matrix2.M14) + (matrix1.M42 * matrix2.M24)) + (matrix1.M43 * matrix2.M34)) + (matrix1.M44 * matrix2.M44);
+            result.M11 = m11;
+			result.M12 = m12;
+			result.M13 = m13;
+			result.M14 = m14;
+			result.M21 = m21;
+			result.M22 = m22;
+			result.M23 = m23;
+			result.M24 = m24;
+			result.M31 = m31;
+			result.M32 = m32;
+			result.M33 = m33;
+			result.M34 = m34;
+			result.M41 = m41;
+			result.M42 = m42;
+			result.M43 = m43;
+			result.M44 = m44;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains a multiplication of <see cref="Matrix4"/> and a scalar.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <returns>Result of the matrix multiplication with a scalar.</returns>
+        public static Matrix4 Multiply(Matrix4 matrix1, float scaleFactor)
+        {
+            matrix1.M11 *= scaleFactor;
+            matrix1.M12 *= scaleFactor;
+            matrix1.M13 *= scaleFactor;
+            matrix1.M14 *= scaleFactor;
+            matrix1.M21 *= scaleFactor;
+            matrix1.M22 *= scaleFactor;
+            matrix1.M23 *= scaleFactor;
+            matrix1.M24 *= scaleFactor;
+            matrix1.M31 *= scaleFactor;
+            matrix1.M32 *= scaleFactor;
+            matrix1.M33 *= scaleFactor;
+            matrix1.M34 *= scaleFactor;
+            matrix1.M41 *= scaleFactor;
+            matrix1.M42 *= scaleFactor;
+            matrix1.M43 *= scaleFactor;
+            matrix1.M44 *= scaleFactor;
+            return matrix1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains a multiplication of <see cref="Matrix4"/> and a scalar.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/>.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <param name="result">Result of the matrix multiplication with a scalar as an output parameter.</param>
+        public static void Multiply(ref Matrix4 matrix1, float scaleFactor, out Matrix4 result)
+        {
+            result.M11 = matrix1.M11 * scaleFactor;
+            result.M12 = matrix1.M12 * scaleFactor;
+            result.M13 = matrix1.M13 * scaleFactor;
+            result.M14 = matrix1.M14 * scaleFactor;
+            result.M21 = matrix1.M21 * scaleFactor;
+            result.M22 = matrix1.M22 * scaleFactor;
+            result.M23 = matrix1.M23 * scaleFactor;
+            result.M24 = matrix1.M24 * scaleFactor;
+            result.M31 = matrix1.M31 * scaleFactor;
+            result.M32 = matrix1.M32 * scaleFactor;
+            result.M33 = matrix1.M33 * scaleFactor;
+            result.M34 = matrix1.M34 * scaleFactor;
+            result.M41 = matrix1.M41 * scaleFactor;
+            result.M42 = matrix1.M42 * scaleFactor;
+            result.M43 = matrix1.M43 * scaleFactor;
+            result.M44 = matrix1.M44 * scaleFactor;
+
+        }
+
+        /// <summary>
+        /// Copy the values of specified <see cref="Matrix4"/> to the float array.
+        /// </summary>
+        /// <param name="matrix">The source <see cref="Matrix4"/>.</param>
+        /// <returns>The array which matrix values will be stored.</returns>
+        /// <remarks>
+        /// Required for OpenGL 2.0 projection matrix stuff.
+        /// </remarks>
+        public static float[] ToFloatArray(Matrix4 matrix)
+        {
+            float[] matarray = {
+									matrix.M11, matrix.M12, matrix.M13, matrix.M14,
+									matrix.M21, matrix.M22, matrix.M23, matrix.M24,
+									matrix.M31, matrix.M32, matrix.M33, matrix.M34,
+									matrix.M41, matrix.M42, matrix.M43, matrix.M44
+								};
+            return matarray;
+        }
+
+        /// <summary>
+        /// Returns a matrix with the all values negated.
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/>.</param>
+        /// <returns>Result of the matrix negation.</returns>
+        public static Matrix4 Negate(Matrix4 matrix)
+        {
+		    matrix.M11 = -matrix.M11;
+		    matrix.M12 = -matrix.M12;
+		    matrix.M13 = -matrix.M13;
+		    matrix.M14 = -matrix.M14;
+		    matrix.M21 = -matrix.M21;
+		    matrix.M22 = -matrix.M22;
+		    matrix.M23 = -matrix.M23;
+		    matrix.M24 = -matrix.M24;
+		    matrix.M31 = -matrix.M31;
+		    matrix.M32 = -matrix.M32;
+		    matrix.M33 = -matrix.M33;
+		    matrix.M34 = -matrix.M34;
+		    matrix.M41 = -matrix.M41;
+		    matrix.M42 = -matrix.M42;
+		    matrix.M43 = -matrix.M43;
+		    matrix.M44 = -matrix.M44;
+		    return matrix;
+        }
+
+        /// <summary>
+        /// Returns a matrix with the all values negated.
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/>.</param>
+        /// <param name="result">Result of the matrix negation as an output parameter.</param>
+        public static void Negate(ref Matrix4 matrix, out Matrix4 result)
+        {
+            result.M11 = -matrix.M11;
+		    result.M12 = -matrix.M12;
+		    result.M13 = -matrix.M13;
+		    result.M14 = -matrix.M14;
+		    result.M21 = -matrix.M21;
+		    result.M22 = -matrix.M22;
+		    result.M23 = -matrix.M23;
+		    result.M24 = -matrix.M24;
+		    result.M31 = -matrix.M31;
+		    result.M32 = -matrix.M32;
+		    result.M33 = -matrix.M33;
+		    result.M34 = -matrix.M34;
+		    result.M41 = -matrix.M41;
+		    result.M42 = -matrix.M42;
+		    result.M43 = -matrix.M43;
+		    result.M44 = -matrix.M44;
+        }
+
+        /// <summary>
+        /// Adds two matrixes.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/> on the left of the add sign.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/> on the right of the add sign.</param>
+        /// <returns>Sum of the matrixes.</returns>
+        public static Matrix4 operator +(Matrix4 matrix1, Matrix4 matrix2)
+        {
+            matrix1.M11 = matrix1.M11 + matrix2.M11;
+            matrix1.M12 = matrix1.M12 + matrix2.M12;
+            matrix1.M13 = matrix1.M13 + matrix2.M13;
+            matrix1.M14 = matrix1.M14 + matrix2.M14;
+            matrix1.M21 = matrix1.M21 + matrix2.M21;
+            matrix1.M22 = matrix1.M22 + matrix2.M22;
+            matrix1.M23 = matrix1.M23 + matrix2.M23;
+            matrix1.M24 = matrix1.M24 + matrix2.M24;
+            matrix1.M31 = matrix1.M31 + matrix2.M31;
+            matrix1.M32 = matrix1.M32 + matrix2.M32;
+            matrix1.M33 = matrix1.M33 + matrix2.M33;
+            matrix1.M34 = matrix1.M34 + matrix2.M34;
+            matrix1.M41 = matrix1.M41 + matrix2.M41;
+            matrix1.M42 = matrix1.M42 + matrix2.M42;
+            matrix1.M43 = matrix1.M43 + matrix2.M43;
+            matrix1.M44 = matrix1.M44 + matrix2.M44;
+            return matrix1;
+        }
+
+        /// <summary>
+        /// Divides the elements of a <see cref="Matrix4"/> by the elements of another <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/> on the left of the div sign.</param>
+        /// <param name="matrix2">Divisor <see cref="Matrix4"/> on the right of the div sign.</param>
+        /// <returns>The result of dividing the matrixes.</returns>
+        public static Matrix4 operator /(Matrix4 matrix1, Matrix4 matrix2)
+        {
+		    matrix1.M11 = matrix1.M11 / matrix2.M11;
+		    matrix1.M12 = matrix1.M12 / matrix2.M12;
+		    matrix1.M13 = matrix1.M13 / matrix2.M13;
+		    matrix1.M14 = matrix1.M14 / matrix2.M14;
+		    matrix1.M21 = matrix1.M21 / matrix2.M21;
+		    matrix1.M22 = matrix1.M22 / matrix2.M22;
+		    matrix1.M23 = matrix1.M23 / matrix2.M23;
+		    matrix1.M24 = matrix1.M24 / matrix2.M24;
+		    matrix1.M31 = matrix1.M31 / matrix2.M31;
+		    matrix1.M32 = matrix1.M32 / matrix2.M32;
+		    matrix1.M33 = matrix1.M33 / matrix2.M33;
+		    matrix1.M34 = matrix1.M34 / matrix2.M34;
+		    matrix1.M41 = matrix1.M41 / matrix2.M41;
+		    matrix1.M42 = matrix1.M42 / matrix2.M42;
+		    matrix1.M43 = matrix1.M43 / matrix2.M43;
+		    matrix1.M44 = matrix1.M44 / matrix2.M44;
+		    return matrix1;
+        }
+
+        /// <summary>
+        /// Divides the elements of a <see cref="Matrix4"/> by a scalar.
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/> on the left of the div sign.</param>
+        /// <param name="divider">Divisor scalar on the right of the div sign.</param>
+        /// <returns>The result of dividing a matrix by a scalar.</returns>
+        public static Matrix4 operator /(Matrix4 matrix, float divider)
+        {
+		    float num = 1f / divider;
+		    matrix.M11 = matrix.M11 * num;
+		    matrix.M12 = matrix.M12 * num;
+		    matrix.M13 = matrix.M13 * num;
+		    matrix.M14 = matrix.M14 * num;
+		    matrix.M21 = matrix.M21 * num;
+		    matrix.M22 = matrix.M22 * num;
+		    matrix.M23 = matrix.M23 * num;
+		    matrix.M24 = matrix.M24 * num;
+		    matrix.M31 = matrix.M31 * num;
+		    matrix.M32 = matrix.M32 * num;
+		    matrix.M33 = matrix.M33 * num;
+		    matrix.M34 = matrix.M34 * num;
+		    matrix.M41 = matrix.M41 * num;
+		    matrix.M42 = matrix.M42 * num;
+		    matrix.M43 = matrix.M43 * num;
+		    matrix.M44 = matrix.M44 * num;
+		    return matrix;
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Matrix4"/> instances are equal without any tolerance.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/> on the left of the equal sign.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/> on the right of the equal sign.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(Matrix4 matrix1, Matrix4 matrix2)
+        {
+            return (
+                matrix1.M11 == matrix2.M11 &&
+                matrix1.M12 == matrix2.M12 &&
+                matrix1.M13 == matrix2.M13 &&
+                matrix1.M14 == matrix2.M14 &&
+                matrix1.M21 == matrix2.M21 &&
+                matrix1.M22 == matrix2.M22 &&
+                matrix1.M23 == matrix2.M23 &&
+                matrix1.M24 == matrix2.M24 &&
+                matrix1.M31 == matrix2.M31 &&
+                matrix1.M32 == matrix2.M32 &&
+                matrix1.M33 == matrix2.M33 &&
+                matrix1.M34 == matrix2.M34 &&
+                matrix1.M41 == matrix2.M41 &&
+                matrix1.M42 == matrix2.M42 &&
+                matrix1.M43 == matrix2.M43 &&
+                matrix1.M44 == matrix2.M44                  
+                );
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Matrix4"/> instances are not equal without any tolerance.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/> on the left of the not equal sign.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/> on the right of the not equal sign.</param>
+        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>
+        public static bool operator !=(Matrix4 matrix1, Matrix4 matrix2)
+        {
+            return (
+                matrix1.M11 != matrix2.M11 ||
+                matrix1.M12 != matrix2.M12 ||
+                matrix1.M13 != matrix2.M13 ||
+                matrix1.M14 != matrix2.M14 ||
+                matrix1.M21 != matrix2.M21 ||
+                matrix1.M22 != matrix2.M22 ||
+                matrix1.M23 != matrix2.M23 ||
+                matrix1.M24 != matrix2.M24 ||
+                matrix1.M31 != matrix2.M31 ||
+                matrix1.M32 != matrix2.M32 ||
+                matrix1.M33 != matrix2.M33 ||
+                matrix1.M34 != matrix2.M34 || 
+                matrix1.M41 != matrix2.M41 ||
+                matrix1.M42 != matrix2.M42 ||
+                matrix1.M43 != matrix2.M43 ||
+                matrix1.M44 != matrix2.M44                  
+                );
+        }
+
+        /// <summary>
+        /// Multiplies two matrixes.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/> on the left of the mul sign.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/> on the right of the mul sign.</param>
+        /// <returns>Result of the matrix multiplication.</returns>
+        /// <remarks>
+        /// Using matrix multiplication algorithm - see http://en.wikipedia.org/wiki/Matrix_multiplication.
+        /// </remarks>
+        public static Matrix4 operator *(Matrix4 matrix1, Matrix4 matrix2)
+        {
+            var m11 = (((matrix1.M11 * matrix2.M11) + (matrix1.M12 * matrix2.M21)) + (matrix1.M13 * matrix2.M31)) + (matrix1.M14 * matrix2.M41);
+            var m12 = (((matrix1.M11 * matrix2.M12) + (matrix1.M12 * matrix2.M22)) + (matrix1.M13 * matrix2.M32)) + (matrix1.M14 * matrix2.M42);
+            var m13 = (((matrix1.M11 * matrix2.M13) + (matrix1.M12 * matrix2.M23)) + (matrix1.M13 * matrix2.M33)) + (matrix1.M14 * matrix2.M43);
+            var m14 = (((matrix1.M11 * matrix2.M14) + (matrix1.M12 * matrix2.M24)) + (matrix1.M13 * matrix2.M34)) + (matrix1.M14 * matrix2.M44);
+            var m21 = (((matrix1.M21 * matrix2.M11) + (matrix1.M22 * matrix2.M21)) + (matrix1.M23 * matrix2.M31)) + (matrix1.M24 * matrix2.M41);
+            var m22 = (((matrix1.M21 * matrix2.M12) + (matrix1.M22 * matrix2.M22)) + (matrix1.M23 * matrix2.M32)) + (matrix1.M24 * matrix2.M42);
+            var m23 = (((matrix1.M21 * matrix2.M13) + (matrix1.M22 * matrix2.M23)) + (matrix1.M23 * matrix2.M33)) + (matrix1.M24 * matrix2.M43);
+            var m24 = (((matrix1.M21 * matrix2.M14) + (matrix1.M22 * matrix2.M24)) + (matrix1.M23 * matrix2.M34)) + (matrix1.M24 * matrix2.M44);
+            var m31 = (((matrix1.M31 * matrix2.M11) + (matrix1.M32 * matrix2.M21)) + (matrix1.M33 * matrix2.M31)) + (matrix1.M34 * matrix2.M41);
+            var m32 = (((matrix1.M31 * matrix2.M12) + (matrix1.M32 * matrix2.M22)) + (matrix1.M33 * matrix2.M32)) + (matrix1.M34 * matrix2.M42);
+            var m33 = (((matrix1.M31 * matrix2.M13) + (matrix1.M32 * matrix2.M23)) + (matrix1.M33 * matrix2.M33)) + (matrix1.M34 * matrix2.M43);
+            var m34 = (((matrix1.M31 * matrix2.M14) + (matrix1.M32 * matrix2.M24)) + (matrix1.M33 * matrix2.M34)) + (matrix1.M34 * matrix2.M44);
+            var m41 = (((matrix1.M41 * matrix2.M11) + (matrix1.M42 * matrix2.M21)) + (matrix1.M43 * matrix2.M31)) + (matrix1.M44 * matrix2.M41);
+            var m42 = (((matrix1.M41 * matrix2.M12) + (matrix1.M42 * matrix2.M22)) + (matrix1.M43 * matrix2.M32)) + (matrix1.M44 * matrix2.M42);
+            var m43 = (((matrix1.M41 * matrix2.M13) + (matrix1.M42 * matrix2.M23)) + (matrix1.M43 * matrix2.M33)) + (matrix1.M44 * matrix2.M43);
+           	var m44 = (((matrix1.M41 * matrix2.M14) + (matrix1.M42 * matrix2.M24)) + (matrix1.M43 * matrix2.M34)) + (matrix1.M44 * matrix2.M44);
+            matrix1.M11 = m11;
+			matrix1.M12 = m12;
+			matrix1.M13 = m13;
+			matrix1.M14 = m14;
+			matrix1.M21 = m21;
+			matrix1.M22 = m22;
+			matrix1.M23 = m23;
+			matrix1.M24 = m24;
+			matrix1.M31 = m31;
+			matrix1.M32 = m32;
+			matrix1.M33 = m33;
+			matrix1.M34 = m34;
+			matrix1.M41 = m41;
+			matrix1.M42 = m42;
+			matrix1.M43 = m43;
+			matrix1.M44 = m44;
+			return matrix1;
+        }
+
+        /// <summary>
+        /// Multiplies the elements of matrix by a scalar.
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/> on the left of the mul sign.</param>
+        /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
+        /// <returns>Result of the matrix multiplication with a scalar.</returns>
+        public static Matrix4 operator *(Matrix4 matrix, float scaleFactor)
+        {
+		    matrix.M11 = matrix.M11 * scaleFactor;
+		    matrix.M12 = matrix.M12 * scaleFactor;
+		    matrix.M13 = matrix.M13 * scaleFactor;
+		    matrix.M14 = matrix.M14 * scaleFactor;
+		    matrix.M21 = matrix.M21 * scaleFactor;
+		    matrix.M22 = matrix.M22 * scaleFactor;
+		    matrix.M23 = matrix.M23 * scaleFactor;
+		    matrix.M24 = matrix.M24 * scaleFactor;
+		    matrix.M31 = matrix.M31 * scaleFactor;
+		    matrix.M32 = matrix.M32 * scaleFactor;
+		    matrix.M33 = matrix.M33 * scaleFactor;
+		    matrix.M34 = matrix.M34 * scaleFactor;
+		    matrix.M41 = matrix.M41 * scaleFactor;
+		    matrix.M42 = matrix.M42 * scaleFactor;
+		    matrix.M43 = matrix.M43 * scaleFactor;
+		    matrix.M44 = matrix.M44 * scaleFactor;
+		    return matrix;
+        }
+
+        /// <summary>
+        /// Subtracts the values of one <see cref="Matrix4"/> from another <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="matrix1">Source <see cref="Matrix4"/> on the left of the sub sign.</param>
+        /// <param name="matrix2">Source <see cref="Matrix4"/> on the right of the sub sign.</param>
+        /// <returns>Result of the matrix subtraction.</returns>
+        public static Matrix4 operator -(Matrix4 matrix1, Matrix4 matrix2)
+        {
+		    matrix1.M11 = matrix1.M11 - matrix2.M11;
+		    matrix1.M12 = matrix1.M12 - matrix2.M12;
+		    matrix1.M13 = matrix1.M13 - matrix2.M13;
+		    matrix1.M14 = matrix1.M14 - matrix2.M14;
+		    matrix1.M21 = matrix1.M21 - matrix2.M21;
+		    matrix1.M22 = matrix1.M22 - matrix2.M22;
+		    matrix1.M23 = matrix1.M23 - matrix2.M23;
+		    matrix1.M24 = matrix1.M24 - matrix2.M24;
+		    matrix1.M31 = matrix1.M31 - matrix2.M31;
+		    matrix1.M32 = matrix1.M32 - matrix2.M32;
+		    matrix1.M33 = matrix1.M33 - matrix2.M33;
+		    matrix1.M34 = matrix1.M34 - matrix2.M34;
+		    matrix1.M41 = matrix1.M41 - matrix2.M41;
+		    matrix1.M42 = matrix1.M42 - matrix2.M42;
+		    matrix1.M43 = matrix1.M43 - matrix2.M43;
+		    matrix1.M44 = matrix1.M44 - matrix2.M44;
+		    return matrix1;
+        }
+
+        /// <summary>
+        /// Inverts values in the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="matrix">Source <see cref="Matrix4"/> on the right of the sub sign.</param>
+        /// <returns>Result of the inversion.</returns>
+        public static Matrix4 operator -(Matrix4 matrix)
+        {
+		    matrix.M11 = -matrix.M11;
+		    matrix.M12 = -matrix.M12;
+		    matrix.M13 = -matrix.M13;
+		    matrix.M14 = -matrix.M14;
+		    matrix.M21 = -matrix.M21;
+		    matrix.M22 = -matrix.M22;
+		    matrix.M23 = -matrix.M23;
+		    matrix.M24 = -matrix.M24;
+		    matrix.M31 = -matrix.M31;
+		    matrix.M32 = -matrix.M32;
+		    matrix.M33 = -matrix.M33;
+		    matrix.M34 = -matrix.M34;
+		    matrix.M41 = -matrix.M41;
+		    matrix.M42 = -matrix.M42;
+		    matrix.M43 = -matrix.M43;
+		    matrix.M44 = -matrix.M44;
+			return matrix;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains subtraction of one matrix from another.
+        /// </summary>
+        /// <param name="matrix1">The first <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">The second <see cref="Matrix4"/>.</param>
+        /// <returns>The result of the matrix subtraction.</returns>
+        public static Matrix4 Subtract(Matrix4 matrix1, Matrix4 matrix2)
+        {
+		    matrix1.M11 = matrix1.M11 - matrix2.M11;
+		    matrix1.M12 = matrix1.M12 - matrix2.M12;
+		    matrix1.M13 = matrix1.M13 - matrix2.M13;
+		    matrix1.M14 = matrix1.M14 - matrix2.M14;
+		    matrix1.M21 = matrix1.M21 - matrix2.M21;
+		    matrix1.M22 = matrix1.M22 - matrix2.M22;
+		    matrix1.M23 = matrix1.M23 - matrix2.M23;
+		    matrix1.M24 = matrix1.M24 - matrix2.M24;
+		    matrix1.M31 = matrix1.M31 - matrix2.M31;
+		    matrix1.M32 = matrix1.M32 - matrix2.M32;
+		    matrix1.M33 = matrix1.M33 - matrix2.M33;
+		    matrix1.M34 = matrix1.M34 - matrix2.M34;
+		    matrix1.M41 = matrix1.M41 - matrix2.M41;
+		    matrix1.M42 = matrix1.M42 - matrix2.M42;
+		    matrix1.M43 = matrix1.M43 - matrix2.M43;
+		    matrix1.M44 = matrix1.M44 - matrix2.M44;
+		    return matrix1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Matrix4"/> that contains subtraction of one matrix from another.
+        /// </summary>
+        /// <param name="matrix1">The first <see cref="Matrix4"/>.</param>
+        /// <param name="matrix2">The second <see cref="Matrix4"/>.</param>
+        /// <param name="result">The result of the matrix subtraction as an output parameter.</param>
+        public static void Subtract(ref Matrix4 matrix1, ref Matrix4 matrix2, out Matrix4 result)
+        {
+            result.M11 = matrix1.M11 - matrix2.M11;
+		    result.M12 = matrix1.M12 - matrix2.M12;
+		    result.M13 = matrix1.M13 - matrix2.M13;
+		    result.M14 = matrix1.M14 - matrix2.M14;
+		    result.M21 = matrix1.M21 - matrix2.M21;
+		    result.M22 = matrix1.M22 - matrix2.M22;
+		    result.M23 = matrix1.M23 - matrix2.M23;
+		    result.M24 = matrix1.M24 - matrix2.M24;
+		    result.M31 = matrix1.M31 - matrix2.M31;
+		    result.M32 = matrix1.M32 - matrix2.M32;
+		    result.M33 = matrix1.M33 - matrix2.M33;
+		    result.M34 = matrix1.M34 - matrix2.M34;
+		    result.M41 = matrix1.M41 - matrix2.M41;
+		    result.M42 = matrix1.M42 - matrix2.M42;
+		    result.M43 = matrix1.M43 - matrix2.M43;
+		    result.M44 = matrix1.M44 - matrix2.M44;
+        }
+
+        internal string DebugDisplayString
+        {
+            get
+            {
+                if (this == Identity)
+                {
+                    return "Identity";
+                }
+
+                return string.Concat(
+                     "( ", this.M11.ToString(), "  ", this.M12.ToString(), "  ", this.M13.ToString(), "  ", this.M14.ToString(), " )  \r\n",
+                     "( ", this.M21.ToString(), "  ", this.M22.ToString(), "  ", this.M23.ToString(), "  ", this.M24.ToString(), " )  \r\n",
+                     "( ", this.M31.ToString(), "  ", this.M32.ToString(), "  ", this.M33.ToString(), "  ", this.M34.ToString(), " )  \r\n",
+                     "( ", this.M41.ToString(), "  ", this.M42.ToString(), "  ", this.M43.ToString(), "  ", this.M44.ToString(), " )");
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Matrix4"/> in the format:
+        /// {M11:[<see cref="M11"/>] M12:[<see cref="M12"/>] M13:[<see cref="M13"/>] M14:[<see cref="M14"/>]}
+        /// {M21:[<see cref="M21"/>] M12:[<see cref="M22"/>] M13:[<see cref="M23"/>] M14:[<see cref="M24"/>]}
+        /// {M31:[<see cref="M31"/>] M32:[<see cref="M32"/>] M33:[<see cref="M33"/>] M34:[<see cref="M34"/>]}
+        /// {M41:[<see cref="M41"/>] M42:[<see cref="M42"/>] M43:[<see cref="M43"/>] M44:[<see cref="M44"/>]}
+        /// </summary>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Matrix4"/>.</returns>
+        public override string ToString()
+        {
+            return "{M11:" + M11 + " M12:" + M12 + " M13:" + M13 + " M14:" + M14 + "}"
+                + " {M21:" + M21 + " M22:" + M22 + " M23:" + M23 + " M24:" + M24 + "}"
+                + " {M31:" + M31 + " M32:" + M32 + " M33:" + M33 + " M34:" + M34 + "}"
+                + " {M41:" + M41 + " M42:" + M42 + " M43:" + M43 + " M44:" + M44 + "}";
+        }
+
+        /// <summary>
+        /// Swap the matrix rows and columns.
+        /// </summary>
+        /// <param name="matrix">The matrix for transposing operation.</param>
+        /// <returns>The new <see cref="Matrix4"/> which contains the transposing result.</returns>
+        public static Matrix4 Transpose(Matrix4 matrix)
+        {
+            Matrix4 ret;
+            Transpose(ref matrix, out ret);
+            return ret;
+        }
+
+        /// <summary>
+        /// Swap the matrix rows and columns.
+        /// </summary>
+        /// <param name="matrix">The matrix for transposing operation.</param>
+        /// <param name="result">The new <see cref="Matrix4"/> which contains the transposing result as an output parameter.</param>
+        public static void Transpose(ref Matrix4 matrix, out Matrix4 result)
+        {
+            Matrix4 ret;
+            
+            ret.M11 = matrix.M11;
+            ret.M12 = matrix.M21;
+            ret.M13 = matrix.M31;
+            ret.M14 = matrix.M41;
+
+            ret.M21 = matrix.M12;
+            ret.M22 = matrix.M22;
+            ret.M23 = matrix.M32;
+            ret.M24 = matrix.M42;
+
+            ret.M31 = matrix.M13;
+            ret.M32 = matrix.M23;
+            ret.M33 = matrix.M33;
+            ret.M34 = matrix.M43;
+
+            ret.M41 = matrix.M14;
+            ret.M42 = matrix.M24;
+            ret.M43 = matrix.M34;
+            ret.M44 = matrix.M44;
+            
+            result = ret;
+        }
+        #endregion
+		
+		#region Private Static Methods
+        
+        /// <summary>
+        /// Helper method for using the Laplace expansion theorem using two rows expansions to calculate major and 
+        /// minor determinants of a 4x4 matrix. This method is used for inverting a matrix.
+        /// </summary>
+        private static void FindDeterminants(ref Matrix4 matrix, out float major, 
+                                             out float minor1, out float minor2, out float minor3, out float minor4, out float minor5, out float minor6,
+                                             out float minor7, out float minor8, out float minor9, out float minor10, out float minor11, out float minor12)
+        {
+                double det1 = (double)matrix.M11 * (double)matrix.M22 - (double)matrix.M12 * (double)matrix.M21;
+                double det2 = (double)matrix.M11 * (double)matrix.M23 - (double)matrix.M13 * (double)matrix.M21;
+                double det3 = (double)matrix.M11 * (double)matrix.M24 - (double)matrix.M14 * (double)matrix.M21;
+                double det4 = (double)matrix.M12 * (double)matrix.M23 - (double)matrix.M13 * (double)matrix.M22;
+                double det5 = (double)matrix.M12 * (double)matrix.M24 - (double)matrix.M14 * (double)matrix.M22;
+                double det6 = (double)matrix.M13 * (double)matrix.M24 - (double)matrix.M14 * (double)matrix.M23;
+                double det7 = (double)matrix.M31 * (double)matrix.M42 - (double)matrix.M32 * (double)matrix.M41;
+                double det8 = (double)matrix.M31 * (double)matrix.M43 - (double)matrix.M33 * (double)matrix.M41;
+                double det9 = (double)matrix.M31 * (double)matrix.M44 - (double)matrix.M34 * (double)matrix.M41;
+                double det10 = (double)matrix.M32 * (double)matrix.M43 - (double)matrix.M33 * (double)matrix.M42;
+                double det11 = (double)matrix.M32 * (double)matrix.M44 - (double)matrix.M34 * (double)matrix.M42;
+                double det12 = (double)matrix.M33 * (double)matrix.M44 - (double)matrix.M34 * (double)matrix.M43;
+                
+                major = (float)(det1*det12 - det2*det11 + det3*det10 + det4*det9 - det5*det8 + det6*det7);
+                minor1 = (float)det1;
+                minor2 = (float)det2;
+                minor3 = (float)det3;
+                minor4 = (float)det4;
+                minor5 = (float)det5;
+                minor6 = (float)det6;
+                minor7 = (float)det7;
+                minor8 = (float)det8;
+                minor9 = (float)det9;
+                minor10 = (float)det10;
+                minor11 = (float)det11;
+                minor12 = (float)det12;
+        }
+		
+        #endregion
+    }
+}

--- a/tests/GL002/GL002.Demo/OpenTK.dll.config
+++ b/tests/GL002/GL002.Demo/OpenTK.dll.config
@@ -1,0 +1,25 @@
+<configuration>
+  <dllmap os="linux" dll="opengl32.dll" target="libGL.so.1"/>
+  <dllmap os="linux" dll="glu32.dll" target="libGLU.so.1"/>
+  <dllmap os="linux" dll="openal32.dll" target="libopenal.so.1"/>
+  <dllmap os="linux" dll="alut.dll" target="libalut.so.0"/>
+  <dllmap os="linux" dll="opencl.dll" target="libOpenCL.so"/>
+  <dllmap os="linux" dll="libX11" target="libX11.so.6"/>
+  <dllmap os="linux" dll="libXi" target="libXi.so.6"/>
+  <dllmap os="linux" dll="SDL2.dll" target="libSDL2-2.0.so.0"/>
+  <dllmap os="osx" dll="opengl32.dll" target="/System/Library/Frameworks/OpenGL.framework/OpenGL"/>
+  <dllmap os="osx" dll="openal32.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="alut.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="libGLES.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv1_CM.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv2.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="opencl.dll" target="/System/Library/Frameworks/OpenCL.framework/OpenCL"/>
+  <dllmap os="osx" dll="SDL2.dll" target="libSDL2.dylib"/>
+  <!-- XQuartz compatibility (X11 on Mac) -->
+  <dllmap os="osx" dll="libGL.so.1" target="/usr/X11/lib/libGL.dylib"/>
+  <dllmap os="osx" dll="libX11" target="/usr/X11/lib/libX11.dylib"/>
+  <dllmap os="osx" dll="libXcursor.so.1" target="/usr/X11/lib/libXcursor.dylib"/>
+  <dllmap os="osx" dll="libXi" target="/usr/X11/lib/libXi.dylib"/>
+  <dllmap os="osx" dll="libXinerama" target="/usr/X11/lib/libXinerama.dylib"/>
+  <dllmap os="osx" dll="libXrandr.so.2" target="/usr/X11/lib/libXrandr.dylib"/>
+</configuration>

--- a/tests/GL002/GL002.Demo/Program.cs
+++ b/tests/GL002/GL002.Demo/Program.cs
@@ -1,0 +1,155 @@
+﻿using LightInject;
+using Magnesium;
+using OpenTK;
+using System;
+
+namespace TriangleDemo.DesktopGL
+{
+    class Program
+    {
+        public static void Main(string[] args)
+        {
+            try
+            {
+
+                using (var container = new ServiceContainer())
+                using (var window = new NativeWindow())
+                {
+                    window.Title = "Vulkan Example - Basic indexed triangle";
+                    window.Visible = true;
+
+                    container.RegisterInstance<INativeWindow>(window);
+
+                    // Magnesium                    
+                    container.Register<Magnesium.MgDriverContext>(new PerContainerLifetime());
+                    //container.Register<Magnesium.IMgPresentationSurface, Magnesium.PresentationSurfaces.OpenTK.VulkanPresentationSurface>(new PerContainerLifetime());
+                    container.Register<Magnesium.IMgPresentationSurface, Magnesium.PresentationSurfaces.OpenTK.DesktopGLPresentationSurface>(new PerContainerLifetime());
+
+                    container.Register<Magnesium.IMgGraphicsConfiguration, Magnesium.MgDefaultGraphicsConfiguration>(new PerContainerLifetime());
+                    container.Register<Magnesium.IMgImageTools, Magnesium.MgImageTools>(new PerContainerLifetime());
+
+                    // Magnesium.OpenGL.DesktopGL
+                    container.Register<TriangleDemo.ITriangleDemoShaderPath, GLSLTriangleShaderPath>(new PerContainerLifetime());
+                    SetupOpenGL(container);
+
+                    // SCOPE
+                    //container.Register<Magnesium.IMgGraphicsDevice, Magnesium.MgDefaultGraphicsDevice>(new PerScopeLifetime());
+                    // IMgGraphicsDevice
+                    container.Register<Magnesium.IMgGraphicsDevice, Magnesium.OpenGL.DesktopGL.OpenTKGraphicsDevice>(new PerScopeLifetime());
+
+                    container.Register<VulkanExample>(new PerScopeLifetime());
+                    container.Register<Magnesium.IMgPresentationBarrierEntrypoint, Magnesium.MgPresentationBarrierEntrypoint>(new PerScopeLifetime());
+
+                    container.Register<Magnesium.IMgPresentationLayer, Magnesium.MgPresentationLayer>(new PerScopeLifetime());
+                    //container.Register<Magnesium.IMgSwapchainCollection, Magnesium.MgSwapchainCollection>(new PerScopeLifetime());
+                    // IMgSwapchainCollection
+                    container.Register<Magnesium.IMgSwapchainCollection, Magnesium.OpenGL.DesktopGL.OpenTKSwapchainCollection>(new PerScopeLifetime());
+
+
+                    using (var scope = container.BeginScope())
+                    {
+                        using (var driver = container.GetInstance<MgDriverContext>())
+                        {
+                            driver.Initialize(
+                                new MgApplicationInfo
+                                {
+                                    ApplicationName = "Vulkan Example",
+                                    ApiVersion = Magnesium.MgApplicationInfo.GenerateApiVersion(1, 0, 17),
+                                    ApplicationVersion = 1,
+                                    EngineName = "Magnesium",
+                                    EngineVersion = 1,
+                                },
+                                MgInstanceExtensionOptions.ALL);
+                            using (var graphicsConfiguration = container.GetInstance<IMgGraphicsConfiguration>())
+                            {
+                                using (var secondLevel = container.BeginScope())
+                                {
+                                    using (var gameWindow = new GameWindow(window))
+                                    using (var example = container.GetInstance<VulkanExample>())
+                                    {
+                                        gameWindow.RenderFrame += (sender, e) =>
+                                        {
+                                            example.RenderLoop();
+                                        };
+
+                                        gameWindow.Run(60, 60);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+        }
+
+
+        static void SetupOpenGL(ServiceContainer container)
+        {
+            container.Register<Magnesium.IMgTextureGenerator, Magnesium.MgLinearImageOptimizer>(new PerContainerLifetime());
+
+            // Magnesium.OpenGL
+            container.Register<Magnesium.IMgEntrypoint, Magnesium.OpenGL.GLEntrypoint>(new PerContainerLifetime());
+
+            // IMgGraphicsDevice
+            //container.Register<Magnesium.IMgGraphicsDevice, Magnesium.OpenGL.DesktopGL.OpenTKGraphicsDevice>(new PerContainerLifetime());
+
+            // IMgSwapchainCollection
+            //container.Register<Magnesium.IMgSwapchainCollection, Magnesium.OpenGL.DesktopGL.OpenTKSwapchainCollection>(new PerContainerLifetime());
+
+            // Magnesium.OpenGL INTERNALS
+            container.Register<Magnesium.OpenGL.IGLGraphicsPipelineCompiler, Magnesium.OpenGL.GLSLGraphicsPipelineCompilier>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLQueue, Magnesium.OpenGL.GLCmdQueue>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLRenderer, Magnesium.OpenGL.GLCmdRenderer>(new PerContainerLifetime());
+            
+            container.Register<Magnesium.OpenGL.IGLCmdStateRenderer, Magnesium.OpenGL.GLCmdStateRenderer>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLDeviceEntrypoint, Magnesium.OpenGL.DefaultGLDeviceEntrypoint>(new PerContainerLifetime());
+
+            // WINDOW 
+            //container.Register<Magnesium.IMgPresentationSurface, Magnesium.PresentationSurfaces.OpenTK.DesktopGLPresentationSurface>(new PerContainerLifetime());
+
+            container.Register<Magnesium.OpenGL.IGLCmdBlendEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdBlendEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdStencilEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdStencilEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdRasterizationEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdRasterizationEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLErrorHandler, Magnesium.OpenGL.DesktopGL.FullGLErrorHandler>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdDepthEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdDepthEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLNextCmdShaderProgramCache, Magnesium.OpenGL.GLNextCmdShaderProgramCache>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdScissorsEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdScissorsEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdDrawEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdDrawEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdClearEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdClearEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLSemaphoreEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLSemaphoreEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdImageEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdImageEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdVBOEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdVBOEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLSamplerEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLSamplerEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLDeviceImageEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLDeviceImageEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLDeviceImageViewEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLDeviceImageViewEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLImageFormatEntrypoint, Magnesium.OpenGL.DesktopGL.DesktopGLImageFormatEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLImageDescriptorEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLImageDescriptorEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLShaderModuleEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLShaderModuleEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLDescriptorPoolEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLDescriptorPoolEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLBufferEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLBufferEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLDeviceMemoryEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLDeviceMemoryEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLGraphicsPipelineEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLGraphicsPipelineEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLFramebufferHelperSelector, Magnesium.OpenGL.DesktopGL.FullGLFramebufferHelperSelector>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLFramebufferSupport, Magnesium.OpenGL.DesktopGL.FullGLFramebufferSupport>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLExtensionLookup, Magnesium.OpenGL.DesktopGL.FullGLExtensionLookup>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLFenceEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLFullFenceEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLBlitOperationEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLBlitOperationEntrypoint>(new PerContainerLifetime());
+
+            // DESCRIPTOR SET
+            container.Register<Magnesium.OpenGL.IGLUniformBlockEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLUniformBlockEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLUniformBlockNameParser, Magnesium.OpenGL.DefaultGLUniformBlockNameParser>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLCmdShaderProgramEntrypoint, Magnesium.OpenGL.DesktopGL.FullGLCmdShaderProgramEntrypoint>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.IGLDescriptorSetEntrypoint, Magnesium.OpenGL.DefaultGLDescriptorSetEntrypoint>(new PerContainerLifetime());
+
+
+            // Magnesium.OpenGL.DesktopGL INTERNALS
+            container.Register<Magnesium.OpenGL.DesktopGL.IOpenTKSwapchainKHR, Magnesium.OpenGL.DesktopGL.GLSwapchainKHR>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.DesktopGL.IGLBackbufferContext, Magnesium.OpenGL.DesktopGL.OpenTKBackbufferContext>(new PerContainerLifetime());
+            container.Register<Magnesium.OpenGL.DesktopGL.IMgGraphicsDeviceLogger, Magnesium.OpenGL.DesktopGL.NullMgGraphicsDeviceLogger>(new PerContainerLifetime());
+        }
+    }
+}

--- a/tests/GL002/GL002.Demo/Properties/AssemblyInfo.cs
+++ b/tests/GL002/GL002.Demo/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TriangleDemo.DesktopGL")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TriangleDemo.DesktopGL")]
+[assembly: AssemblyCopyright("Copyright ©  2016, 2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("3177b351-bd6a-46c2-a989-ebd66ba965b5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/GL002/GL002.Demo/Shaders/triangle.frag
+++ b/tests/GL002/GL002.Demo/Shaders/triangle.frag
@@ -1,0 +1,13 @@
+#version 450
+
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+
+layout (location = 0) in vec3 inColor;
+
+layout (location = 0) out vec4 outFragColor;
+
+void fragFunc() 
+{
+  outFragColor = vec4(inColor, 1.0);
+}

--- a/tests/GL002/GL002.Demo/Shaders/triangle.vert
+++ b/tests/GL002/GL002.Demo/Shaders/triangle.vert
@@ -1,0 +1,29 @@
+#version 450
+
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shading_language_420pack : enable
+
+layout (location = 0) in vec3 inPos;
+layout (location = 1) in vec3 inColor;
+
+layout (std140, binding = 0) uniform UBO 
+{
+	mat4 projectionMatrix;
+	mat4 modelMatrix;
+	mat4 viewMatrix;
+} ubo;
+
+layout (location = 0) out vec3 outColor;
+
+out gl_PerVertex 
+{
+    vec4 gl_Position;   
+};
+
+
+void vertFunc() 
+{
+	outColor = inColor;
+	gl_Position = ubo.projectionMatrix * ubo.viewMatrix * ubo.modelMatrix * vec4(inPos.xyz, 1.0);
+	gl_Position.y *= -1.0f;
+}

--- a/tests/GL002/GL002.Demo/Vector3.cs
+++ b/tests/GL002/GL002.Demo/Vector3.cs
@@ -1,0 +1,958 @@
+// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+
+namespace TriangleDemo
+{
+    /// <summary>
+    /// Describes a 3D-vector.
+    /// </summary>
+    [DebuggerDisplay("{DebugDisplayString,nq}")]
+    public struct Vector3 : IEquatable<Vector3>
+    {
+        #region Private Fields
+
+		private static readonly Vector3 mZero = new Vector3(0f, 0f, 0f);
+		private static readonly Vector3 mOne = new Vector3(1f, 1f, 1f);
+		private static readonly Vector3 mUnitX = new Vector3(1f, 0f, 0f);
+		private static readonly Vector3 mUnitY = new Vector3(0f, 1f, 0f);
+		private static readonly Vector3 mUnitZ = new Vector3(0f, 0f, 1f);
+		private static readonly Vector3 mUp = new Vector3(0f, 1f, 0f);
+		private static readonly Vector3 mDown = new Vector3(0f, -1f, 0f);
+		private static readonly Vector3 mRight = new Vector3(1f, 0f, 0f);
+		private static readonly Vector3 mLeft = new Vector3(-1f, 0f, 0f);
+		private static readonly Vector3 mForward = new Vector3(0f, 0f, -1f);
+		private static readonly Vector3 mBackward = new Vector3(0f, 0f, 1f);
+
+        #endregion
+
+        #region Public Fields
+
+        /// <summary>
+        /// The x coordinate of this <see cref="Vector3"/>.
+        /// </summary>
+        public float X;
+
+        /// <summary>
+        /// The y coordinate of this <see cref="Vector3"/>.
+        /// </summary>
+        public float Y;
+
+        /// <summary>
+        /// The z coordinate of this <see cref="Vector3"/>.
+        /// </summary>
+        public float Z;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 0, 0.
+        /// </summary>
+        public static Vector3 Zero
+        {
+            get { return mZero; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 1, 1, 1.
+        /// </summary>
+        public static Vector3 One
+        {
+            get { return mOne; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 1, 0, 0.
+        /// </summary>
+        public static Vector3 UnitX
+        {
+            get { return mUnitX; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 1, 0.
+        /// </summary>
+        public static Vector3 UnitY
+        {
+            get { return mUnitY; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 0, 1.
+        /// </summary>
+        public static Vector3 UnitZ
+        {
+            get { return mUnitZ; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 1, 0.
+        /// </summary>
+        public static Vector3 Up
+        {
+            get { return mUp; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, -1, 0.
+        /// </summary>
+        public static Vector3 Down
+        {
+            get { return mDown; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 1, 0, 0.
+        /// </summary>
+        public static Vector3 Right
+        {
+            get { return mRight; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components -1, 0, 0.
+        /// </summary>
+        public static Vector3 Left
+        {
+            get { return mLeft; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 0, -1.
+        /// </summary>
+        public static Vector3 Forward
+        {
+            get { return mForward; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector3"/> with components 0, 0, 1.
+        /// </summary>
+        public static Vector3 Backward
+        {
+            get { return mBackward; }
+        }
+
+        #endregion
+
+        #region Internal Properties
+
+        internal string DebugDisplayString
+        {
+            get
+            {
+                return string.Concat(
+                    this.X.ToString(), "  ",
+                    this.Y.ToString(), "  ",
+                    this.Z.ToString()
+                );
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructs a 3d vector with X, Y and Z from three values.
+        /// </summary>
+        /// <param name="x">The x coordinate in 3d-space.</param>
+        /// <param name="y">The y coordinate in 3d-space.</param>
+        /// <param name="z">The z coordinate in 3d-space.</param>
+        public Vector3(float x, float y, float z)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
+        }
+
+        /// <summary>
+        /// Constructs a 3d vector with X, Y and Z set to the same value.
+        /// </summary>
+        /// <param name="value">The x, y and z coordinates in 3d-space.</param>
+        public Vector3(float value)
+        {
+            this.X = value;
+            this.Y = value;
+            this.Z = value;
+        }
+
+       
+        #endregion
+        
+        #region Public Methods
+
+        /// <summary>
+        /// Performs vector addition on <paramref name="value1"/> and <paramref name="value2"/>.
+        /// </summary>
+        /// <param name="value1">The first vector to add.</param>
+        /// <param name="value2">The second vector to add.</param>
+        /// <returns>The result of the vector addition.</returns>
+        public static Vector3 Add(Vector3 value1, Vector3 value2)
+        {
+            value1.X += value2.X;
+            value1.Y += value2.Y;
+            value1.Z += value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Performs vector addition on <paramref name="value1"/> and
+        /// <paramref name="value2"/>, storing the result of the
+        /// addition in <paramref name="result"/>.
+        /// </summary>
+        /// <param name="value1">The first vector to add.</param>
+        /// <param name="value2">The second vector to add.</param>
+        /// <param name="result">The result of the vector addition.</param>
+        public static void Add(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
+        {
+            result.X = value1.X + value2.X;
+            result.Y = value1.Y + value2.Y;
+            result.Z = value1.Z + value2.Z;
+        }
+
+        /// <summary>
+        /// Computes the cross product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <returns>The cross product of two vectors.</returns>
+        public static Vector3 Cross(Vector3 vector1, Vector3 vector2)
+        {
+            Cross(ref vector1, ref vector2, out vector1);
+            return vector1;
+        }
+
+        /// <summary>
+        /// Computes the cross product of two vectors.
+        /// </summary>
+        /// <param name="vector1">The first vector.</param>
+        /// <param name="vector2">The second vector.</param>
+        /// <param name="result">The cross product of two vectors as an output parameter.</param>
+        public static void Cross(ref Vector3 vector1, ref Vector3 vector2, out Vector3 result)
+        {
+            var x = vector1.Y * vector2.Z - vector2.Y * vector1.Z;
+            var y = -(vector1.X * vector2.Z - vector2.X * vector1.Z);
+            var z = vector1.X * vector2.Y - vector2.X * vector1.Y;
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
+        }
+
+        /// <summary>
+        /// Returns the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The distance between two vectors.</returns>
+        public static float Distance(Vector3 value1, Vector3 value2)
+        {
+            float result;
+            DistanceSquared(ref value1, ref value2, out result);
+            return (float)Math.Sqrt(result);
+        }
+
+        /// <summary>
+        /// Returns the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The distance between two vectors as an output parameter.</param>
+        public static void Distance(ref Vector3 value1, ref Vector3 value2, out float result)
+        {
+            DistanceSquared(ref value1, ref value2, out result);
+            result = (float)Math.Sqrt(result);
+        }
+
+        /// <summary>
+        /// Returns the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The squared distance between two vectors.</returns>
+        public static float DistanceSquared(Vector3 value1, Vector3 value2)
+        {
+            return  (value1.X - value2.X) * (value1.X - value2.X) +
+                    (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                    (value1.Z - value2.Z) * (value1.Z - value2.Z);
+        }
+
+        /// <summary>
+        /// Returns the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The squared distance between two vectors as an output parameter.</param>
+        public static void DistanceSquared(ref Vector3 value1, ref Vector3 value2, out float result)
+        {
+            result = (value1.X - value2.X) * (value1.X - value2.X) +
+                     (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                     (value1.Z - value2.Z) * (value1.Z - value2.Z);
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by the components of another <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="value2">Divisor <see cref="Vector3"/>.</param>
+        /// <returns>The result of dividing the vectors.</returns>
+        public static Vector3 Divide(Vector3 value1, Vector3 value2)
+        {
+            value1.X /= value2.X;
+            value1.Y /= value2.Y;
+            value1.Z /= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="divider">Divisor scalar.</param>
+        /// <returns>The result of dividing a vector by a scalar.</returns>
+        public static Vector3 Divide(Vector3 value1, float divider)
+        {
+            float factor = 1 / divider;
+            value1.X *= factor;
+            value1.Y *= factor;
+            value1.Z *= factor;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="divider">Divisor scalar.</param>
+        /// <param name="result">The result of dividing a vector by a scalar as an output parameter.</param>
+        public static void Divide(ref Vector3 value1, float divider, out Vector3 result)
+        {
+            float factor = 1 / divider;
+            result.X = value1.X * factor;
+            result.Y = value1.Y * factor;
+            result.Z = value1.Z * factor;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by the components of another <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="value2">Divisor <see cref="Vector3"/>.</param>
+        /// <param name="result">The result of dividing the vectors as an output parameter.</param>
+        public static void Divide(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
+        {
+            result.X = value1.X / value2.X;
+            result.Y = value1.Y / value2.Y;
+            result.Z = value1.Z / value2.Z;
+        }
+
+        /// <summary>
+        /// Returns a dot product of two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The dot product of two vectors.</returns>
+        public static float Dot(Vector3 value1, Vector3 value2)
+        {
+            return value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z;
+        }
+
+        /// <summary>
+        /// Returns a dot product of two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The dot product of two vectors as an output parameter.</param>
+        public static void Dot(ref Vector3 value1, ref Vector3 value2, out float result)
+        {
+            result = value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z;
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Object"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="Object"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Vector3))
+                return false;
+
+            var other = (Vector3)obj;
+            return  X == other.X &&
+                    Y == other.Y &&
+                    Z == other.Z;
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="Vector3"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public bool Equals(Vector3 other)
+        {
+            return  X == other.X && 
+                    Y == other.Y &&
+                    Z == other.Z;
+        }
+
+        /// <summary>
+        /// Gets the hash code of this <see cref="Vector3"/>.
+        /// </summary>
+        /// <returns>Hash code of this <see cref="Vector3"/>.</returns>
+        public override int GetHashCode()
+        {
+            return (int)(this.X + this.Y + this.Z);
+        }
+
+        /// <summary>
+        /// Returns the length of this <see cref="Vector3"/>.
+        /// </summary>
+        /// <returns>The length of this <see cref="Vector3"/>.</returns>
+        public float Length()
+        {
+            float result = DistanceSquared(this, mZero);
+            return (float)Math.Sqrt(result);
+        }
+
+        /// <summary>
+        /// Returns the squared length of this <see cref="Vector3"/>.
+        /// </summary>
+        /// <returns>The squared length of this <see cref="Vector3"/>.</returns>
+        public float LengthSquared()
+        {
+            return DistanceSquared(this, mZero);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a multiplication of two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="value2">Source <see cref="Vector3"/>.</param>
+        /// <returns>The result of the vector multiplication.</returns>
+        public static Vector3 Multiply(Vector3 value1, Vector3 value2)
+        {
+            value1.X *= value2.X;
+            value1.Y *= value2.Y;
+            value1.Z *= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a multiplication of <see cref="Vector3"/> and a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <returns>The result of the vector multiplication with a scalar.</returns>
+        public static Vector3 Multiply(Vector3 value1, float scaleFactor)
+        {
+            value1.X *= scaleFactor;
+            value1.Y *= scaleFactor;
+            value1.Z *= scaleFactor;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a multiplication of <see cref="Vector3"/> and a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <param name="result">The result of the multiplication with a scalar as an output parameter.</param>
+        public static void Multiply(ref Vector3 value1, float scaleFactor, out Vector3 result)
+        {
+            result.X = value1.X * scaleFactor;
+            result.Y = value1.Y * scaleFactor;
+            result.Z = value1.Z * scaleFactor;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a multiplication of two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="value2">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">The result of the vector multiplication as an output parameter.</param>
+        public static void Multiply(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
+        {
+            result.X = value1.X * value2.X;
+            result.Y = value1.Y * value2.Y;
+            result.Z = value1.Z * value2.Z;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains the specified vector inversion.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <returns>The result of the vector inversion.</returns>
+        public static Vector3 Negate(Vector3 value)
+        {
+            value = new Vector3(-value.X, -value.Y, -value.Z);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains the specified vector inversion.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">The result of the vector inversion as an output parameter.</param>
+        public static void Negate(ref Vector3 value, out Vector3 result)
+        {
+            result.X = -value.X;
+            result.Y = -value.Y;
+            result.Z = -value.Z;
+        }
+
+        /// <summary>
+        /// Turns this <see cref="Vector3"/> to a unit vector with the same direction.
+        /// </summary>
+        public void Normalize()
+        {
+            Normalize(ref this, out this);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a normalized values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector3 Normalize(Vector3 value)
+        {
+            float factor = Distance(value, mZero);
+            factor = 1f / factor;
+            return new Vector3(value.X * factor, value.Y * factor, value.Z * factor);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a normalized values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Normalize(ref Vector3 value, out Vector3 result)
+        {
+            float factor = Distance(value, mZero);
+            factor = 1f / factor;
+            result.X = value.X * factor;
+            result.Y = value.Y * factor;
+            result.Z = value.Z * factor;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains reflect vector of the given vector and normal.
+        /// </summary>
+        /// <param name="vector">Source <see cref="Vector3"/>.</param>
+        /// <param name="normal">Reflection normal.</param>
+        /// <returns>Reflected vector.</returns>
+        public static Vector3 Reflect(Vector3 vector, Vector3 normal)
+        {
+            // I is the original array
+            // N is the normal of the incident plane
+            // R = I - (2 * N * ( DotProduct[ I,N] ))
+            Vector3 reflectedVector;
+            // inline the dotProduct here instead of calling method
+            float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+            reflectedVector.X = vector.X - (2.0f * normal.X) * dotProduct;
+            reflectedVector.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
+            reflectedVector.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
+
+            return reflectedVector;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains reflect vector of the given vector and normal.
+        /// </summary>
+        /// <param name="vector">Source <see cref="Vector3"/>.</param>
+        /// <param name="normal">Reflection normal.</param>
+        /// <param name="result">Reflected vector as an output parameter.</param>
+        public static void Reflect(ref Vector3 vector, ref Vector3 normal, out Vector3 result)
+        {
+            // I is the original array
+            // N is the normal of the incident plane
+            // R = I - (2 * N * ( DotProduct[ I,N] ))
+
+            // inline the dotProduct here instead of calling method
+            float dotProduct = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+            result.X = vector.X - (2.0f * normal.X) * dotProduct;
+            result.Y = vector.Y - (2.0f * normal.Y) * dotProduct;
+            result.Z = vector.Z - (2.0f * normal.Z) * dotProduct;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains subtraction of on <see cref="Vector3"/> from a another.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="value2">Source <see cref="Vector3"/>.</param>
+        /// <returns>The result of the vector subtraction.</returns>
+        public static Vector3 Subtract(Vector3 value1, Vector3 value2)
+        {
+            value1.X -= value2.X;
+            value1.Y -= value2.Y;
+            value1.Z -= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains subtraction of on <see cref="Vector3"/> from a another.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/>.</param>
+        /// <param name="value2">Source <see cref="Vector3"/>.</param>
+        /// <param name="result">The result of the vector subtraction as an output parameter.</param>
+        public static void Subtract(ref Vector3 value1, ref Vector3 value2, out Vector3 result)
+        {
+            result.X = value1.X - value2.X;
+            result.Y = value1.Y - value2.Y;
+            result.Z = value1.Z - value2.Z;
+        }
+
+        /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Vector3"/> in the format:
+        /// {X:[<see cref="X"/>] Y:[<see cref="Y"/>] Z:[<see cref="Z"/>]}
+        /// </summary>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Vector3"/>.</returns>
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder(32);
+            sb.Append("{X:");
+            sb.Append(this.X);
+            sb.Append(" Y:");
+            sb.Append(this.Y);
+            sb.Append(" Z:");
+            sb.Append(this.Z);
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        #region Transform
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a transformation of 3d-vector by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="position">Source <see cref="Vector3"/>.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <returns>Transformed <see cref="Vector3"/>.</returns>
+        public static Vector3 Transform(Vector3 position, Matrix4 matrix)
+        {
+            Transform(ref position, ref matrix, out position);
+            return position;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a transformation of 3d-vector by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="position">Source <see cref="Vector3"/>.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="result">Transformed <see cref="Vector3"/> as an output parameter.</param>
+        public static void Transform(ref Vector3 position, ref Matrix4 matrix, out Vector3 result)
+        {
+            var x = (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41;
+            var y = (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42;
+            var z = (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43;
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
+        }
+
+        /// <summary>
+        /// Apply transformation on vectors within array of <see cref="Vector3"/> by the specified <see cref="Matrix4"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="sourceIndex">The starting index of transformation in the source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        /// <param name="destinationIndex">The starting index in the destination array, where the first <see cref="Vector3"/> should be written.</param>
+        /// <param name="length">The number of vectors to be transformed.</param>
+        public static void Transform(Vector3[] sourceArray, int sourceIndex, ref Matrix4 matrix, Vector3[] destinationArray, int destinationIndex, int length)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException("sourceArray");
+            if (destinationArray == null)
+                throw new ArgumentNullException("destinationArray");
+            if (sourceArray.Length < sourceIndex + length)
+                throw new ArgumentException("Source array length is lesser than sourceIndex + length");
+            if (destinationArray.Length < destinationIndex + length)
+                throw new ArgumentException("Destination array length is lesser than destinationIndex + length");
+
+            // TODO: Are there options on some platforms to implement a vectorized version of this?
+
+            for (var i = 0; i < length; i++)
+            {
+                var position = sourceArray[sourceIndex + i];
+                destinationArray[destinationIndex + i] =
+                    new Vector3(
+                        (position.X * matrix.M11) + (position.Y * matrix.M21) + (position.Z * matrix.M31) + matrix.M41,
+                        (position.X * matrix.M12) + (position.Y * matrix.M22) + (position.Z * matrix.M32) + matrix.M42,
+                        (position.X * matrix.M13) + (position.Y * matrix.M23) + (position.Z * matrix.M33) + matrix.M43);
+            }
+        }
+
+        /// <summary>
+        /// Apply transformation on all vectors within array of <see cref="Vector3"/> by the specified <see cref="Matrix4"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        public static void Transform(Vector3[] sourceArray, ref Matrix4 matrix, Vector3[] destinationArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException("sourceArray");
+            if (destinationArray == null)
+                throw new ArgumentNullException("destinationArray");
+            if (destinationArray.Length < sourceArray.Length)
+                throw new ArgumentException("Destination array length is lesser than source array length");
+
+            // TODO: Are there options on some platforms to implement a vectorized version of this?
+
+            for (var i = 0; i < sourceArray.Length; i++)
+            {
+                var position = sourceArray[i];                
+                destinationArray[i] =
+                    new Vector3(
+                        (position.X*matrix.M11) + (position.Y*matrix.M21) + (position.Z*matrix.M31) + matrix.M41,
+                        (position.X*matrix.M12) + (position.Y*matrix.M22) + (position.Z*matrix.M32) + matrix.M42,
+                        (position.X*matrix.M13) + (position.Y*matrix.M23) + (position.Z*matrix.M33) + matrix.M43);
+            }
+        }
+
+        #endregion
+
+        #region TransformNormal
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a transformation of the specified normal by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="normal">Source <see cref="Vector3"/> which represents a normal vector.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <returns>Transformed normal.</returns>
+        public static Vector3 TransformNormal(Vector3 normal, Matrix4 matrix)
+        {
+            TransformNormal(ref normal, ref matrix, out normal);
+            return normal;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector3"/> that contains a transformation of the specified normal by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="normal">Source <see cref="Vector3"/> which represents a normal vector.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="result">Transformed normal as an output parameter.</param>
+        public static void TransformNormal(ref Vector3 normal, ref Matrix4 matrix, out Vector3 result)
+        {
+            var x = (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31);
+            var y = (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32);
+            var z = (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33);
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
+        }
+
+        /// <summary>
+        /// Apply transformation on normals within array of <see cref="Vector3"/> by the specified <see cref="Matrix4"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="sourceIndex">The starting index of transformation in the source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        /// <param name="destinationIndex">The starting index in the destination array, where the first <see cref="Vector3"/> should be written.</param>
+        /// <param name="length">The number of normals to be transformed.</param>
+        public static void TransformNormal(Vector3[] sourceArray,
+         int sourceIndex,
+         ref Matrix4 matrix,
+         Vector3[] destinationArray,
+         int destinationIndex,
+         int length)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException("sourceArray");
+            if (destinationArray == null)
+                throw new ArgumentNullException("destinationArray");
+            if(sourceArray.Length < sourceIndex + length)
+                throw new ArgumentException("Source array length is lesser than sourceIndex + length");
+            if (destinationArray.Length < destinationIndex + length)
+                throw new ArgumentException("Destination array length is lesser than destinationIndex + length");
+
+            for (int x = 0; x < length; x++)
+            {
+                var normal = sourceArray[sourceIndex + x];
+
+                destinationArray[destinationIndex + x] =
+                     new Vector3(
+                        (normal.X * matrix.M11) + (normal.Y * matrix.M21) + (normal.Z * matrix.M31),
+                        (normal.X * matrix.M12) + (normal.Y * matrix.M22) + (normal.Z * matrix.M32),
+                        (normal.X * matrix.M13) + (normal.Y * matrix.M23) + (normal.Z * matrix.M33));
+            }
+        }
+
+        /// <summary>
+        /// Apply transformation on all normals within array of <see cref="Vector3"/> by the specified <see cref="Matrix4"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        public static void TransformNormal(Vector3[] sourceArray, ref Matrix4 matrix, Vector3[] destinationArray)
+        {
+            if(sourceArray == null)
+                throw new ArgumentNullException("sourceArray");
+            if (destinationArray == null)
+                throw new ArgumentNullException("destinationArray");
+            if (destinationArray.Length < sourceArray.Length)
+                throw new ArgumentException("Destination array length is lesser than source array length");
+
+            for (var i = 0; i < sourceArray.Length; i++)
+            {
+                var normal = sourceArray[i];
+
+                destinationArray[i] =
+                    new Vector3(
+                        (normal.X*matrix.M11) + (normal.Y*matrix.M21) + (normal.Z*matrix.M31),
+                        (normal.X*matrix.M12) + (normal.Y*matrix.M22) + (normal.Z*matrix.M32),
+                        (normal.X*matrix.M13) + (normal.Y*matrix.M23) + (normal.Z*matrix.M33));
+            }
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Operators
+
+        /// <summary>
+        /// Compares whether two <see cref="Vector3"/> instances are equal.
+        /// </summary>
+        /// <param name="value1"><see cref="Vector3"/> instance on the left of the equal sign.</param>
+        /// <param name="value2"><see cref="Vector3"/> instance on the right of the equal sign.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(Vector3 value1, Vector3 value2)
+        {
+            return value1.X == value2.X
+                && value1.Y == value2.Y
+                && value1.Z == value2.Z;
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Vector3"/> instances are not equal.
+        /// </summary>
+        /// <param name="value1"><see cref="Vector3"/> instance on the left of the not equal sign.</param>
+        /// <param name="value2"><see cref="Vector3"/> instance on the right of the not equal sign.</param>
+        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        public static bool operator !=(Vector3 value1, Vector3 value2)
+        {
+            return !(value1 == value2);
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the add sign.</param>
+        /// <param name="value2">Source <see cref="Vector3"/> on the right of the add sign.</param>
+        /// <returns>Sum of the vectors.</returns>
+        public static Vector3 operator +(Vector3 value1, Vector3 value2)
+        {
+            value1.X += value2.X;
+            value1.Y += value2.Y;
+            value1.Z += value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Inverts values in the specified <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/> on the right of the sub sign.</param>
+        /// <returns>Result of the inversion.</returns>
+        public static Vector3 operator -(Vector3 value)
+        {
+            value = new Vector3(-value.X, -value.Y, -value.Z);
+            return value;
+        }
+
+        /// <summary>
+        /// Subtracts a <see cref="Vector3"/> from a <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the sub sign.</param>
+        /// <param name="value2">Source <see cref="Vector3"/> on the right of the sub sign.</param>
+        /// <returns>Result of the vector subtraction.</returns>
+        public static Vector3 operator -(Vector3 value1, Vector3 value2)
+        {
+            value1.X -= value2.X;
+            value1.Y -= value2.Y;
+            value1.Z -= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Multiplies the components of two vectors by each other.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the mul sign.</param>
+        /// <param name="value2">Source <see cref="Vector3"/> on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication.</returns>
+        public static Vector3 operator *(Vector3 value1, Vector3 value2)
+        {
+            value1.X *= value2.X;
+            value1.Y *= value2.Y;
+            value1.Z *= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Multiplies the components of vector by a scalar.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/> on the left of the mul sign.</param>
+        /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector3 operator *(Vector3 value, float scaleFactor)
+        {
+            value.X *= scaleFactor;
+            value.Y *= scaleFactor;
+            value.Z *= scaleFactor;
+            return value;
+        }
+
+        /// <summary>
+        /// Multiplies the components of vector by a scalar.
+        /// </summary>
+        /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
+        /// <param name="value">Source <see cref="Vector3"/> on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector3 operator *(float scaleFactor, Vector3 value)
+        {
+            value.X *= scaleFactor;
+            value.Y *= scaleFactor;
+            value.Z *= scaleFactor;
+            return value;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by the components of another <see cref="Vector3"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the div sign.</param>
+        /// <param name="value2">Divisor <see cref="Vector3"/> on the right of the div sign.</param>
+        /// <returns>The result of dividing the vectors.</returns>
+        public static Vector3 operator /(Vector3 value1, Vector3 value2)
+        {
+            value1.X /= value2.X;
+            value1.Y /= value2.Y;
+            value1.Z /= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector3"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector3"/> on the left of the div sign.</param>
+        /// <param name="divider">Divisor scalar on the right of the div sign.</param>
+        /// <returns>The result of dividing a vector by a scalar.</returns>
+        public static Vector3 operator /(Vector3 value1, float divider)
+        {
+            float factor = 1 / divider;
+            value1.X *= factor;
+            value1.Y *= factor;
+            value1.Z *= factor;
+            return value1;
+        }
+
+        #endregion
+    }
+}

--- a/tests/GL002/GL002.Demo/Vector4.cs
+++ b/tests/GL002/GL002.Demo/Vector4.cs
@@ -1,0 +1,805 @@
+// MIT License - Copyright (C) The Mono.Xna Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using System.Runtime.Serialization;
+using System.Diagnostics;
+
+namespace TriangleDemo
+{
+    /// <summary>
+    /// Describes a 4D-vector.
+    /// </summary>
+    [DebuggerDisplay("{DebugDisplayString,nq}")]
+    public struct Vector4 : IEquatable<Vector4>
+    {
+        #region Private Fields
+
+        private static readonly Vector4 zero = new Vector4();
+        private static readonly Vector4 one = new Vector4(1f, 1f, 1f, 1f);
+        private static readonly Vector4 unitX = new Vector4(1f, 0f, 0f, 0f);
+        private static readonly Vector4 unitY = new Vector4(0f, 1f, 0f, 0f);
+        private static readonly Vector4 unitZ = new Vector4(0f, 0f, 1f, 0f);
+        private static readonly Vector4 unitW = new Vector4(0f, 0f, 0f, 1f);
+
+        #endregion
+
+        #region Public Fields
+
+        /// <summary>
+        /// The x coordinate of this <see cref="Vector4"/>.
+        /// </summary>
+        public float X;
+
+        /// <summary>
+        /// The y coordinate of this <see cref="Vector4"/>.
+        /// </summary>
+        public float Y;
+
+        /// <summary>
+        /// The z coordinate of this <see cref="Vector4"/>.
+        /// </summary>
+        public float Z;
+
+        /// <summary>
+        /// The w coordinate of this <see cref="Vector4"/>.
+        /// </summary>
+        public float W;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> with components 0, 0, 0, 0.
+        /// </summary>
+        public static Vector4 Zero
+        {
+            get { return zero; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> with components 1, 1, 1, 1.
+        /// </summary>
+        public static Vector4 One
+        {
+            get { return one; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> with components 1, 0, 0, 0.
+        /// </summary>
+        public static Vector4 UnitX
+        {
+            get { return unitX; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> with components 0, 1, 0, 0.
+        /// </summary>
+        public static Vector4 UnitY
+        {
+            get { return unitY; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> with components 0, 0, 1, 0.
+        /// </summary>
+        public static Vector4 UnitZ
+        {
+            get { return unitZ; }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="Vector4"/> with components 0, 0, 0, 1.
+        /// </summary>
+        public static Vector4 UnitW
+        {
+            get { return unitW; }
+        }
+
+        #endregion
+
+        #region Internal Properties
+
+        internal string DebugDisplayString
+        {
+            get
+            {
+                return string.Concat(
+                    this.X.ToString(), "  ",
+                    this.Y.ToString(), "  ",
+                    this.Z.ToString(), "  ",
+                    this.W.ToString()
+                );
+            }
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructs a 3d vector with X, Y, Z and W from four values.
+        /// </summary>
+        /// <param name="x">The x coordinate in 4d-space.</param>
+        /// <param name="y">The y coordinate in 4d-space.</param>
+        /// <param name="z">The z coordinate in 4d-space.</param>
+        /// <param name="w">The w coordinate in 4d-space.</param>
+        public Vector4(float x, float y, float z, float w)
+        {
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
+            this.W = w;
+        }
+
+        /// <summary>
+        /// Constructs a 3d vector with X, Y, Z from <see cref="Vector3"/> and W from a scalar.
+        /// </summary>
+        /// <param name="value">The x, y and z coordinates in 4d-space.</param>
+        /// <param name="w">The w coordinate in 4d-space.</param>
+        public Vector4(Vector3 value, float w)
+        {
+            this.X = value.X;
+            this.Y = value.Y;
+            this.Z = value.Z;
+            this.W = w;
+        }
+
+        /// <summary>
+        /// Constructs a 4d vector with X, Y, Z and W set to the same value.
+        /// </summary>
+        /// <param name="value">The x, y, z and w coordinates in 4d-space.</param>
+        public Vector4(float value)
+        {
+            this.X = value;
+            this.Y = value;
+            this.Z = value;
+            this.W = value;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Performs vector addition on <paramref name="value1"/> and <paramref name="value2"/>.
+        /// </summary>
+        /// <param name="value1">The first vector to add.</param>
+        /// <param name="value2">The second vector to add.</param>
+        /// <returns>The result of the vector addition.</returns>
+        public static Vector4 Add(Vector4 value1, Vector4 value2)
+        {
+            value1.X += value2.X;
+            value1.Y += value2.Y;
+            value1.Z += value2.Z;
+            value1.W += value2.W;
+            return value1;
+        }
+
+        /// <summary>
+        /// Performs vector addition on <paramref name="value1"/> and
+        /// <paramref name="value2"/>, storing the result of the
+        /// addition in <paramref name="result"/>.
+        /// </summary>
+        /// <param name="value1">The first vector to add.</param>
+        /// <param name="value2">The second vector to add.</param>
+        /// <param name="result">The result of the vector addition.</param>
+        public static void Add(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
+        {
+            result.X = value1.X + value2.X;
+            result.Y = value1.Y + value2.Y;
+            result.Z = value1.Z + value2.Z;
+            result.W = value1.W + value2.W;
+        }
+
+        /// <summary>
+        /// Returns the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The distance between two vectors.</returns>
+        public static float Distance(Vector4 value1, Vector4 value2)
+        {
+            return (float)Math.Sqrt(DistanceSquared(value1, value2));
+        }
+
+        /// <summary>
+        /// Returns the distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The distance between two vectors as an output parameter.</param>
+        public static void Distance(ref Vector4 value1, ref Vector4 value2, out float result)
+        {
+            result = (float)Math.Sqrt(DistanceSquared(value1, value2));
+        }
+
+        /// <summary>
+        /// Returns the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The squared distance between two vectors.</returns>
+        public static float DistanceSquared(Vector4 value1, Vector4 value2)
+        {
+              return (value1.W - value2.W) * (value1.W - value2.W) +
+                     (value1.X - value2.X) * (value1.X - value2.X) +
+                     (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                     (value1.Z - value2.Z) * (value1.Z - value2.Z);
+        }
+
+        /// <summary>
+        /// Returns the squared distance between two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The squared distance between two vectors as an output parameter.</param>
+        public static void DistanceSquared(ref Vector4 value1, ref Vector4 value2, out float result)
+        {
+            result = (value1.W - value2.W) * (value1.W - value2.W) +
+                     (value1.X - value2.X) * (value1.X - value2.X) +
+                     (value1.Y - value2.Y) * (value1.Y - value2.Y) +
+                     (value1.Z - value2.Z) * (value1.Z - value2.Z);
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector4"/> by the components of another <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="value2">Divisor <see cref="Vector4"/>.</param>
+        /// <returns>The result of dividing the vectors.</returns>
+        public static Vector4 Divide(Vector4 value1, Vector4 value2)
+        {
+            value1.W /= value2.W;
+            value1.X /= value2.X;
+            value1.Y /= value2.Y;
+            value1.Z /= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector4"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="divider">Divisor scalar.</param>
+        /// <returns>The result of dividing a vector by a scalar.</returns>
+        public static Vector4 Divide(Vector4 value1, float divider)
+        {
+            float factor = 1f / divider;
+            value1.W *= factor;
+            value1.X *= factor;
+            value1.Y *= factor;
+            value1.Z *= factor;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector4"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="divider">Divisor scalar.</param>
+        /// <param name="result">The result of dividing a vector by a scalar as an output parameter.</param>
+        public static void Divide(ref Vector4 value1, float divider, out Vector4 result)
+        {
+            float factor = 1f / divider;
+            result.W = value1.W * factor;
+            result.X = value1.X * factor;
+            result.Y = value1.Y * factor;
+            result.Z = value1.Z * factor;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector4"/> by the components of another <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="value2">Divisor <see cref="Vector4"/>.</param>
+        /// <param name="result">The result of dividing the vectors as an output parameter.</param>
+        public static void Divide(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
+        {
+            result.W = value1.W / value2.W;
+            result.X = value1.X / value2.X;
+            result.Y = value1.Y / value2.Y;
+            result.Z = value1.Z / value2.Z;
+        }
+
+        /// <summary>
+        /// Returns a dot product of two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <returns>The dot product of two vectors.</returns>
+        public static float Dot(Vector4 value1, Vector4 value2)
+        {
+            return value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z + value1.W * value2.W;
+        }
+
+        /// <summary>
+        /// Returns a dot product of two vectors.
+        /// </summary>
+        /// <param name="value1">The first vector.</param>
+        /// <param name="value2">The second vector.</param>
+        /// <param name="result">The dot product of two vectors as an output parameter.</param>
+        public static void Dot(ref Vector4 value1, ref Vector4 value2, out float result)
+        {
+            result = value1.X * value2.X + value1.Y * value2.Y + value1.Z * value2.Z + value1.W * value2.W;
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Object"/>.
+        /// </summary>
+        /// <param name="obj">The <see cref="Object"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            return (obj is Vector4) ? this == (Vector4)obj : false;
+        }
+
+        /// <summary>
+        /// Compares whether current instance is equal to specified <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="Vector4"/> to compare.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public bool Equals(Vector4 other)
+        {
+            return this.W == other.W
+                && this.X == other.X
+                && this.Y == other.Y
+                && this.Z == other.Z;
+        }
+
+        /// <summary>
+        /// Gets the hash code of this <see cref="Vector4"/>.
+        /// </summary>
+        /// <returns>Hash code of this <see cref="Vector4"/>.</returns>
+        public override int GetHashCode()
+        {
+            return (int)(this.W + this.X + this.Y + this.Y);
+        }
+
+        /// <summary>
+        /// Returns the length of this <see cref="Vector4"/>.
+        /// </summary>
+        /// <returns>The length of this <see cref="Vector4"/>.</returns>
+        public float Length()
+        {
+            float result = DistanceSquared(this, zero);
+            return (float)Math.Sqrt(result);
+        }
+
+        /// <summary>
+        /// Returns the squared length of this <see cref="Vector4"/>.
+        /// </summary>
+        /// <returns>The squared length of this <see cref="Vector4"/>.</returns>
+        public float LengthSquared()
+        {
+            return DistanceSquared(this, zero);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a multiplication of two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="value2">Source <see cref="Vector4"/>.</param>
+        /// <returns>The result of the vector multiplication.</returns>
+        public static Vector4 Multiply(Vector4 value1, Vector4 value2)
+        {
+            value1.W *= value2.W;
+            value1.X *= value2.X;
+            value1.Y *= value2.Y;
+            value1.Z *= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a multiplication of <see cref="Vector4"/> and a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <returns>The result of the vector multiplication with a scalar.</returns>
+        public static Vector4 Multiply(Vector4 value1, float scaleFactor)
+        {
+            value1.W *= scaleFactor;
+            value1.X *= scaleFactor;
+            value1.Y *= scaleFactor;
+            value1.Z *= scaleFactor;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a multiplication of <see cref="Vector4"/> and a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="scaleFactor">Scalar value.</param>
+        /// <param name="result">The result of the multiplication with a scalar as an output parameter.</param>
+        public static void Multiply(ref Vector4 value1, float scaleFactor, out Vector4 result)
+        {
+            result.W = value1.W * scaleFactor;
+            result.X = value1.X * scaleFactor;
+            result.Y = value1.Y * scaleFactor;
+            result.Z = value1.Z * scaleFactor;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a multiplication of two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="value2">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">The result of the vector multiplication as an output parameter.</param>
+        public static void Multiply(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
+        {
+            result.W = value1.W * value2.W;
+            result.X = value1.X * value2.X;
+            result.Y = value1.Y * value2.Y;
+            result.Z = value1.Z * value2.Z;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains the specified vector inversion.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <returns>The result of the vector inversion.</returns>
+        public static Vector4 Negate(Vector4 value)
+        {
+            value = new Vector4(-value.X, -value.Y, -value.Z, -value.W);
+            return value;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains the specified vector inversion.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">The result of the vector inversion as an output parameter.</param>
+        public static void Negate(ref Vector4 value, out Vector4 result)
+        {
+            result.X = -value.X;
+            result.Y = -value.Y;
+            result.Z = -value.Z;
+            result.W = -value.W;
+        }
+
+        /// <summary>
+        /// Turns this <see cref="Vector4"/> to a unit vector with the same direction.
+        /// </summary>
+        public void Normalize()
+        {
+            Normalize(ref this, out this);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a normalized values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <returns>Unit vector.</returns>
+        public static Vector4 Normalize(Vector4 value)
+        {
+            float factor = DistanceSquared(value, zero);
+            factor = 1f / (float)Math.Sqrt(factor);
+
+            return new Vector4(value.X*factor,value.Y*factor,value.Z*factor,value.W*factor);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a normalized values from another vector.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">Unit vector as an output parameter.</param>
+        public static void Normalize(ref Vector4 value, out Vector4 result)
+        {
+            float factor = DistanceSquared(value, zero);
+            factor = 1f / (float)Math.Sqrt(factor);
+
+            result.W = value.W * factor;
+            result.X = value.X * factor;
+            result.Y = value.Y * factor;
+            result.Z = value.Z * factor;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains subtraction of on <see cref="Vector4"/> from a another.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="value2">Source <see cref="Vector4"/>.</param>
+        /// <returns>The result of the vector subtraction.</returns>
+        public static Vector4 Subtract(Vector4 value1, Vector4 value2)
+        {
+            value1.W -= value2.W;
+            value1.X -= value2.X;
+            value1.Y -= value2.Y;
+            value1.Z -= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains subtraction of on <see cref="Vector4"/> from a another.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/>.</param>
+        /// <param name="value2">Source <see cref="Vector4"/>.</param>
+        /// <param name="result">The result of the vector subtraction as an output parameter.</param>
+        public static void Subtract(ref Vector4 value1, ref Vector4 value2, out Vector4 result)
+        {
+            result.W = value1.W - value2.W;
+            result.X = value1.X - value2.X;
+            result.Y = value1.Y - value2.Y;
+            result.Z = value1.Z - value2.Z;
+        }
+
+        #region Transform
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a transformation of 3d-vector by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        public static Vector4 Transform(Vector3 value, Matrix4 matrix)
+        {
+            Vector4 result;
+            Transform(ref value, ref matrix, out result);
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a transformation of 4d-vector by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <returns>Transformed <see cref="Vector4"/>.</returns>
+        public static Vector4 Transform(Vector4 value, Matrix4 matrix)
+        {
+            Transform(ref value, ref matrix, out value);
+            return value;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a transformation of 3d-vector by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector3"/>.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
+        public static void Transform(ref Vector3 value, ref Matrix4 matrix, out Vector4 result)
+        {
+            result.X = (value.X * matrix.M11) + (value.Y * matrix.M21) + (value.Z * matrix.M31) + matrix.M41;
+            result.Y = (value.X * matrix.M12) + (value.Y * matrix.M22) + (value.Z * matrix.M32) + matrix.M42;
+            result.Z = (value.X * matrix.M13) + (value.Y * matrix.M23) + (value.Z * matrix.M33) + matrix.M43;
+            result.W = (value.X * matrix.M14) + (value.Y * matrix.M24) + (value.Z * matrix.M34) + matrix.M44;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Vector4"/> that contains a transformation of 4d-vector by the specified <see cref="Matrix4"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/>.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="result">Transformed <see cref="Vector4"/> as an output parameter.</param>
+        public static void Transform(ref Vector4 value, ref Matrix4 matrix, out Vector4 result)
+        {
+            var x = (value.X * matrix.M11) + (value.Y * matrix.M21) + (value.Z * matrix.M31) + (value.W * matrix.M41);
+            var y = (value.X * matrix.M12) + (value.Y * matrix.M22) + (value.Z * matrix.M32) + (value.W * matrix.M42);
+            var z = (value.X * matrix.M13) + (value.Y * matrix.M23) + (value.Z * matrix.M33) + (value.W * matrix.M43);
+            var w = (value.X * matrix.M14) + (value.Y * matrix.M24) + (value.Z * matrix.M34) + (value.W * matrix.M44);
+            result.X = x;
+            result.Y = y;
+            result.Z = z;
+            result.W = w;
+        }
+
+        /// <summary>
+        /// Apply transformation on vectors within array of <see cref="Vector4"/> by the specified <see cref="Matrix4"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="sourceIndex">The starting index of transformation in the source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        /// <param name="destinationIndex">The starting index in the destination array, where the first <see cref="Vector4"/> should be written.</param>
+        /// <param name="length">The number of vectors to be transformed.</param>
+        public static void Transform
+        (
+            Vector4[] sourceArray,
+            int sourceIndex,
+            ref Matrix4 matrix,
+            Vector4[] destinationArray,
+            int destinationIndex,
+            int length
+        )
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException("sourceArray");
+            if (destinationArray == null)
+                throw new ArgumentNullException("destinationArray");
+            if (sourceArray.Length < sourceIndex + length)
+                throw new ArgumentException("Source array length is lesser than sourceIndex + length");
+            if (destinationArray.Length < destinationIndex + length)
+                throw new ArgumentException("Destination array length is lesser than destinationIndex + length");
+
+            for (var i = 0; i < length; i++)
+            {
+                var value = sourceArray[sourceIndex + i];
+                destinationArray[destinationIndex + i] = Transform(value, matrix);
+            }
+        }
+
+        /// <summary>
+        /// Apply transformation on all vectors within array of <see cref="Vector4"/> by the specified <see cref="Matrix4"/> and places the results in an another array.
+        /// </summary>
+        /// <param name="sourceArray">Source array.</param>
+        /// <param name="matrix">The transformation <see cref="Matrix4"/>.</param>
+        /// <param name="destinationArray">Destination array.</param>
+        public static void Transform(Vector4[] sourceArray, ref Matrix4 matrix, Vector4[] destinationArray)
+        {
+            if (sourceArray == null)
+                throw new ArgumentNullException("sourceArray");
+            if (destinationArray == null)
+                throw new ArgumentNullException("destinationArray");
+            if (destinationArray.Length < sourceArray.Length)
+                throw new ArgumentException("Destination array length is lesser than source array length");
+
+            for (var i = 0; i < sourceArray.Length; i++)
+            {
+                var value = sourceArray[i];
+                destinationArray[i] = Transform(value, matrix);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Returns a <see cref="String"/> representation of this <see cref="Vector4"/> in the format:
+        /// {X:[<see cref="X"/>] Y:[<see cref="Y"/>] Z:[<see cref="Z"/>] W:[<see cref="W"/>]}
+        /// </summary>
+        /// <returns>A <see cref="String"/> representation of this <see cref="Vector4"/>.</returns>
+        public override string ToString()
+        {
+            return "{X:" + X + " Y:" + Y + " Z:" + Z + " W:" + W + "}";
+        }
+
+        #endregion
+
+        #region Operators
+
+        /// <summary>
+        /// Inverts values in the specified <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/> on the right of the sub sign.</param>
+        /// <returns>Result of the inversion.</returns>
+        public static Vector4 operator -(Vector4 value)
+        {
+            return new Vector4(-value.X, -value.Y, -value.Z, -value.W);
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Vector4"/> instances are equal.
+        /// </summary>
+        /// <param name="value1"><see cref="Vector4"/> instance on the left of the equal sign.</param>
+        /// <param name="value2"><see cref="Vector4"/> instance on the right of the equal sign.</param>
+        /// <returns><c>true</c> if the instances are equal; <c>false</c> otherwise.</returns>
+        public static bool operator ==(Vector4 value1, Vector4 value2)
+        {
+            return value1.W == value2.W
+                && value1.X == value2.X
+                && value1.Y == value2.Y
+                && value1.Z == value2.Z;
+        }
+
+        /// <summary>
+        /// Compares whether two <see cref="Vector4"/> instances are not equal.
+        /// </summary>
+        /// <param name="value1"><see cref="Vector4"/> instance on the left of the not equal sign.</param>
+        /// <param name="value2"><see cref="Vector4"/> instance on the right of the not equal sign.</param>
+        /// <returns><c>true</c> if the instances are not equal; <c>false</c> otherwise.</returns>	
+        public static bool operator !=(Vector4 value1, Vector4 value2)
+        {
+            return !(value1 == value2);
+        }
+
+        /// <summary>
+        /// Adds two vectors.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/> on the left of the add sign.</param>
+        /// <param name="value2">Source <see cref="Vector4"/> on the right of the add sign.</param>
+        /// <returns>Sum of the vectors.</returns>
+        public static Vector4 operator +(Vector4 value1, Vector4 value2)
+        {
+            value1.W += value2.W;
+            value1.X += value2.X;
+            value1.Y += value2.Y;
+            value1.Z += value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Subtracts a <see cref="Vector4"/> from a <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/> on the left of the sub sign.</param>
+        /// <param name="value2">Source <see cref="Vector4"/> on the right of the sub sign.</param>
+        /// <returns>Result of the vector subtraction.</returns>
+        public static Vector4 operator -(Vector4 value1, Vector4 value2)
+        {
+            value1.W -= value2.W;
+            value1.X -= value2.X;
+            value1.Y -= value2.Y;
+            value1.Z -= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Multiplies the components of two vectors by each other.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/> on the left of the mul sign.</param>
+        /// <param name="value2">Source <see cref="Vector4"/> on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication.</returns>
+        public static Vector4 operator *(Vector4 value1, Vector4 value2)
+        {
+            value1.W *= value2.W;
+            value1.X *= value2.X;
+            value1.Y *= value2.Y;
+            value1.Z *= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Multiplies the components of vector by a scalar.
+        /// </summary>
+        /// <param name="value">Source <see cref="Vector4"/> on the left of the mul sign.</param>
+        /// <param name="scaleFactor">Scalar value on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector4 operator *(Vector4 value, float scaleFactor)
+        {
+            value.W *= scaleFactor;
+            value.X *= scaleFactor;
+            value.Y *= scaleFactor;
+            value.Z *= scaleFactor;
+            return value;
+        }
+
+        /// <summary>
+        /// Multiplies the components of vector by a scalar.
+        /// </summary>
+        /// <param name="scaleFactor">Scalar value on the left of the mul sign.</param>
+        /// <param name="value">Source <see cref="Vector4"/> on the right of the mul sign.</param>
+        /// <returns>Result of the vector multiplication with a scalar.</returns>
+        public static Vector4 operator *(float scaleFactor, Vector4 value)
+        {
+            value.W *= scaleFactor;
+            value.X *= scaleFactor;
+            value.Y *= scaleFactor;
+            value.Z *= scaleFactor;
+            return value;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector4"/> by the components of another <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/> on the left of the div sign.</param>
+        /// <param name="value2">Divisor <see cref="Vector4"/> on the right of the div sign.</param>
+        /// <returns>The result of dividing the vectors.</returns>
+        public static Vector4 operator /(Vector4 value1, Vector4 value2)
+        {
+            value1.W /= value2.W;
+            value1.X /= value2.X;
+            value1.Y /= value2.Y;
+            value1.Z /= value2.Z;
+            return value1;
+        }
+
+        /// <summary>
+        /// Divides the components of a <see cref="Vector4"/> by a scalar.
+        /// </summary>
+        /// <param name="value1">Source <see cref="Vector4"/> on the left of the div sign.</param>
+        /// <param name="divider">Divisor scalar on the right of the div sign.</param>
+        /// <returns>The result of dividing a vector by a scalar.</returns>
+        public static Vector4 operator /(Vector4 value1, float divider)
+        {
+            float factor = 1f / divider;
+            value1.W *= factor;
+            value1.X *= factor;
+            value1.Y *= factor;
+            value1.Z *= factor;
+            return value1;
+        }
+
+        #endregion
+    }
+}

--- a/tests/GL002/GL002.Demo/VulkanExample.cs
+++ b/tests/GL002/GL002.Demo/VulkanExample.cs
@@ -1,0 +1,1070 @@
+/*
+* Translation into C# and Magnesium interface 2016
+* Vulkan Example - Basic indexed triangle rendering by 2016 by Copyright (C) Sascha Willems - www.saschawillems.de
+*
+* This code is licensed under the MIT license (MIT) (http://opensource.org/licenses/MIT)
+*/
+
+using Magnesium;
+using System.Collections.Generic;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace TriangleDemo
+{
+    public class VulkanExample : IDisposable
+    {
+        // Vertex buffer and attributes
+        class VertexBufferInfo
+        {
+            public IMgDeviceMemory memory;	// Handle to the device memory for this buffer
+            public IMgBuffer buffer; // Handle to the Vulkan buffer object that the memory is bound to
+            public MgPipelineVertexInputStateCreateInfo inputState;
+            public MgVertexInputBindingDescription inputBinding;
+            public MgVertexInputAttributeDescription[] inputAttributes;
+        }
+
+        VertexBufferInfo vertices = new VertexBufferInfo();
+
+        struct IndicesInfo
+        {
+            public IMgDeviceMemory memory;
+            public IMgBuffer buffer;
+            public UInt32 count;
+        }
+
+        IndicesInfo indices = new IndicesInfo();
+
+        private IMgGraphicsConfiguration mConfiguration;
+
+        // Uniform block object
+        struct UniformData
+        {
+            public IMgDeviceMemory memory;
+            public IMgBuffer buffer;
+            public MgDescriptorBufferInfo descriptor;
+        }
+
+        struct UniformBufferObject
+        {
+            public Matrix4 projectionMatrix;
+            public Matrix4 modelMatrix;
+            public Matrix4 viewMatrix;
+        };
+
+        UniformBufferObject uboVS;
+
+
+        UniformData uniformDataVS = new UniformData();
+        IMgPipelineLayout mPipelineLayout;
+        IMgPipeline mPipeline;
+        IMgDescriptorSetLayout mDescriptorSetLayout;
+        IMgDescriptorSet mDescriptorSet;
+        IMgSemaphore mPresentCompleteSemaphore;
+        IMgSemaphore mRenderCompleteSemaphore;
+
+        List<IMgFence> mWaitFences = new List<IMgFence>();
+
+        private uint mWidth;
+        private uint mHeight;
+        private IMgGraphicsDevice mGraphicsDevice;
+        private IMgDescriptorPool mDescriptorPool;
+
+        private IMgCommandBuffer mPrePresentCmdBuffer;
+        private IMgCommandBuffer mPostPresentCmdBuffer;
+        private IMgPresentationLayer mPresentationLayer;
+
+        public VulkanExample
+        (
+            IMgGraphicsConfiguration configuration,
+            IMgSwapchainCollection swapchains,
+            IMgGraphicsDevice graphicsDevice,
+            IMgPresentationLayer presentationLayer,
+            ITriangleDemoShaderPath shaderPath
+        )
+        {
+            mConfiguration = configuration;
+            mSwapchains = swapchains;
+            mGraphicsDevice = graphicsDevice;
+            mPresentationLayer = presentationLayer;
+            mTrianglePath = shaderPath;
+
+            mWidth = 1280U;
+            mHeight = 720U;
+
+            try
+            {
+                mConfiguration.Initialize(mWidth, mHeight);
+                InitSwapchain(mWidth, mHeight);
+                Prepare();
+            }
+            catch(Exception ex)
+            {
+                throw ex;
+            }
+        }
+
+        private IMgSwapchainCollection mSwapchains;
+        private void InitSwapchain(uint width, uint height)
+        {
+            Debug.Assert(mConfiguration.Partition != null);
+
+
+            const int NO_OF_BUFFERS = 1;
+            var buffers = new IMgCommandBuffer[NO_OF_BUFFERS];
+            var pAllocateInfo = new MgCommandBufferAllocateInfo
+            {
+                CommandBufferCount = NO_OF_BUFFERS,
+                CommandPool = mConfiguration.Partition.CommandPool,
+                Level = MgCommandBufferLevel.PRIMARY,
+            };
+
+            mConfiguration.Device.AllocateCommandBuffers(pAllocateInfo, buffers);
+
+            var createInfo = new MgGraphicsDeviceCreateInfo
+            {
+                Samples = MgSampleCountFlagBits.COUNT_1_BIT,
+                Color = MgFormat.R8G8B8A8_UINT,
+                DepthStencil = MgFormat.D24_UNORM_S8_UINT,
+                Width = mWidth,
+                Height = mHeight,
+            };
+
+            var setupCmdBuffer = buffers[0];
+
+            var cmdBufInfo = new MgCommandBufferBeginInfo();
+
+            var err = setupCmdBuffer.BeginCommandBuffer(cmdBufInfo);
+            Debug.Assert(err == Result.SUCCESS);
+
+            mGraphicsDevice.Create(setupCmdBuffer, mSwapchains, createInfo);
+
+            err = setupCmdBuffer.EndCommandBuffer();
+            Debug.Assert(err == Result.SUCCESS);
+
+
+            var submission = new[] {
+                new MgSubmitInfo
+                {
+                    CommandBuffers = new IMgCommandBuffer[]
+                    {
+                        buffers[0],
+                    },
+                }
+            };
+
+            err = mConfiguration.Queue.QueueSubmit(submission, null);
+            Debug.Assert(err == Result.SUCCESS);
+
+            mConfiguration.Queue.QueueWaitIdle();
+
+            mConfiguration.Device.FreeCommandBuffers(mConfiguration.Partition.CommandPool, buffers);
+        }
+
+        #region prepare
+
+        private bool mPrepared = false;
+        void Prepare()
+        {
+            BeforePrepare();
+
+            PrepareSynchronizationPrimitives();
+            PrepareVertices();
+            PrepareUniformBuffers();
+            SetupDescriptorSetLayout();
+            PreparePipelines();
+            SetupDescriptorPool();
+            SetupDescriptorSet();
+            BuildCommandBuffers();
+            mPrepared = true;
+        }
+
+        private void BeforePrepare()
+        {
+            CreateCommandBuffers();
+        }
+
+        void PrepareSynchronizationPrimitives()
+        {
+            var semaphoreCreateInfo = new MgSemaphoreCreateInfo { };
+
+            Debug.Assert(mConfiguration.Device != null);
+
+            var err = mConfiguration.Device.CreateSemaphore(semaphoreCreateInfo, null, out mPresentCompleteSemaphore);
+            Debug.Assert(err == Result.SUCCESS);
+
+            err = mConfiguration.Device.CreateSemaphore(semaphoreCreateInfo, null, out mRenderCompleteSemaphore);
+            Debug.Assert(err == Result.SUCCESS);
+
+            var fenceCreateInfo = new MgFenceCreateInfo {
+                Flags = MgFenceCreateFlagBits.SIGNALED_BIT,
+            };
+
+            var noOfCommandBuffers = drawCmdBuffers.Length; 
+            for (var i = 0; i < noOfCommandBuffers; ++i)
+            {
+                IMgFence fence;
+                err = mConfiguration.Device.CreateFence(fenceCreateInfo, null, out fence);
+                Debug.Assert(err == Result.SUCCESS);
+                mWaitFences.Add(fence);
+            }
+        }
+
+        struct TriangleVertex
+        {
+            public Vector3 position;
+            public Vector3 color;
+        };
+
+        class StagingBuffer
+        {
+            public IMgDeviceMemory memory;
+            public IMgBuffer buffer;
+        };
+
+        void PrepareVertices()
+        {
+            TriangleVertex[] vertexBuffer =
+            {
+                new TriangleVertex{
+                    position =new Vector3(1.0f,  1.0f, 0.0f),
+                    color = new Vector3( 1.0f, 0.0f, 0.0f )
+                },
+
+                new TriangleVertex{
+                    position =new Vector3(-1.0f,  1.0f, 0.0f ),
+                    color = new Vector3( 0.0f, 1.0f, 0.0f )
+                },
+
+                new TriangleVertex{
+                    position =new Vector3( 0.0f, -1.0f, 0.0f ),
+                    color = new Vector3( 0.0f, 0.0f, 1.0f )
+                },
+            };
+
+            var structSize = Marshal.SizeOf(typeof(TriangleVertex));
+            var vertexBufferSize = (ulong)(vertexBuffer.Length * structSize);
+
+            UInt32[] indexBuffer = { 0, 1, 2 };
+            indices.count = (uint)indexBuffer.Length;
+            var indexBufferSize = indices.count * sizeof(UInt32);
+
+            var stagingBuffers = new
+            {
+                vertices = new StagingBuffer(),
+                indices = new StagingBuffer(),
+            };
+
+            {
+                var vertexBufferInfo = new MgBufferCreateInfo
+                {
+                    Size = vertexBufferSize,
+                    Usage = MgBufferUsageFlagBits.TRANSFER_SRC_BIT,
+                };
+
+                var err = mConfiguration.Device.CreateBuffer(vertexBufferInfo, null, out stagingBuffers.vertices.buffer);
+                Debug.Assert(err == Result.SUCCESS);
+
+                mConfiguration.Device.GetBufferMemoryRequirements(stagingBuffers.vertices.buffer, out MgMemoryRequirements memReqs);
+
+                var isValid = mConfiguration.Partition.GetMemoryType(memReqs.MemoryTypeBits,
+                    MgMemoryPropertyFlagBits.HOST_VISIBLE_BIT | MgMemoryPropertyFlagBits.HOST_COHERENT_BIT,
+                    out uint typeIndex);
+
+                Debug.Assert(isValid);
+
+                MgMemoryAllocateInfo memAlloc = new MgMemoryAllocateInfo
+                {
+                    AllocationSize = memReqs.Size,
+                    MemoryTypeIndex = typeIndex,
+                };
+
+                err = mConfiguration.Device.AllocateMemory(memAlloc, null, out stagingBuffers.vertices.memory);
+                Debug.Assert(err == Result.SUCCESS);
+
+                // Map and copy
+                err = stagingBuffers.vertices.memory.MapMemory(mConfiguration.Device, 0, memAlloc.AllocationSize, 0, out IntPtr data);
+                Debug.Assert(err == Result.SUCCESS);
+
+                var offset = 0;
+                foreach (var vertex in vertexBuffer)
+                {
+                    IntPtr dest = IntPtr.Add(data, offset);
+                    Marshal.StructureToPtr(vertex, dest, false);
+                    offset += structSize;
+                }
+
+                stagingBuffers.vertices.memory.UnmapMemory(mConfiguration.Device);
+
+                stagingBuffers.vertices.buffer.BindBufferMemory(mConfiguration.Device, stagingBuffers.vertices.memory, 0);
+                Debug.Assert(err == Result.SUCCESS);
+            }
+
+            {
+                var vertexBufferInfo = new MgBufferCreateInfo
+                {
+                    Size = vertexBufferSize,
+                    Usage = MgBufferUsageFlagBits.VERTEX_BUFFER_BIT | MgBufferUsageFlagBits.TRANSFER_DST_BIT,
+                };
+
+                var err = mConfiguration.Device.CreateBuffer(vertexBufferInfo, null, out vertices.buffer);
+                Debug.Assert(err == Result.SUCCESS);
+
+                mConfiguration.Device.GetBufferMemoryRequirements(vertices.buffer, out MgMemoryRequirements memReqs);
+
+                var isValid = mConfiguration.Partition.GetMemoryType(memReqs.MemoryTypeBits, MgMemoryPropertyFlagBits.DEVICE_LOCAL_BIT, out uint typeIndex);
+                Debug.Assert(isValid);
+
+                var memAlloc = new MgMemoryAllocateInfo
+                {
+                    AllocationSize = memReqs.Size,
+                    MemoryTypeIndex = typeIndex,
+                };
+
+                err = mConfiguration.Device.AllocateMemory(memAlloc, null, out vertices.memory);
+                Debug.Assert(err == Result.SUCCESS);
+
+                err = vertices.buffer.BindBufferMemory(mConfiguration.Device, vertices.memory, 0);
+                Debug.Assert(err == Result.SUCCESS);
+            }
+
+            {
+                var indexbufferInfo = new MgBufferCreateInfo
+                {
+                    Size = indexBufferSize,
+                    Usage = MgBufferUsageFlagBits.TRANSFER_SRC_BIT,
+                };
+
+                var err = mConfiguration.Device.CreateBuffer(indexbufferInfo, null, out stagingBuffers.indices.buffer);
+                Debug.Assert(err == Result.SUCCESS);
+
+                mConfiguration.Device.GetBufferMemoryRequirements(stagingBuffers.indices.buffer, out MgMemoryRequirements memReqs);
+
+                var isValid = mConfiguration.Partition.GetMemoryType(memReqs.MemoryTypeBits,
+                    MgMemoryPropertyFlagBits.HOST_VISIBLE_BIT | MgMemoryPropertyFlagBits.HOST_COHERENT_BIT,
+                    out uint typeIndex);
+                Debug.Assert(isValid);
+
+                var memAlloc = new MgMemoryAllocateInfo
+                {
+                    AllocationSize = memReqs.Size,
+                    MemoryTypeIndex = typeIndex,
+                };
+
+                err = mConfiguration.Device.AllocateMemory(memAlloc, null, out stagingBuffers.indices.memory);
+                Debug.Assert(err == Result.SUCCESS);
+
+                err = stagingBuffers.indices.memory.MapMemory(mConfiguration.Device, 0, indexBufferSize, 0, out IntPtr data);
+                Debug.Assert(err == Result.SUCCESS);
+
+                var uintBuffer = new byte[indexBufferSize];
+
+                var bufferSize = (int)indexBufferSize;
+                Buffer.BlockCopy(indexBuffer, 0, uintBuffer, 0, bufferSize);
+                Marshal.Copy(uintBuffer, 0, data, bufferSize);
+
+                stagingBuffers.indices.memory.UnmapMemory(mConfiguration.Device);
+
+                err = stagingBuffers.indices.buffer.BindBufferMemory(mConfiguration.Device, stagingBuffers.indices.memory, 0);
+                Debug.Assert(err == Result.SUCCESS);
+            }
+
+            {
+                var indexbufferInfo = new MgBufferCreateInfo
+                {
+                    Size = indexBufferSize,
+                    Usage = MgBufferUsageFlagBits.INDEX_BUFFER_BIT | MgBufferUsageFlagBits.TRANSFER_DST_BIT,
+                };
+
+                var err = mConfiguration.Device.CreateBuffer(indexbufferInfo, null, out indices.buffer);
+                Debug.Assert(err == Result.SUCCESS);
+
+                mConfiguration.Device.GetBufferMemoryRequirements(indices.buffer, out MgMemoryRequirements memReqs);
+
+                var isValid = mConfiguration.Partition.GetMemoryType(memReqs.MemoryTypeBits, MgMemoryPropertyFlagBits.DEVICE_LOCAL_BIT, out uint typeIndex);
+                Debug.Assert(isValid);
+
+                var memAlloc = new MgMemoryAllocateInfo
+                {
+                    AllocationSize = memReqs.Size,
+                    MemoryTypeIndex = typeIndex,
+                };
+
+                err = mConfiguration.Device.AllocateMemory(memAlloc, null, out indices.memory);
+                Debug.Assert(err == Result.SUCCESS);
+
+                err = indices.buffer.BindBufferMemory(mConfiguration.Device, indices.memory, 0);
+                Debug.Assert(err == Result.SUCCESS);
+            }
+
+            {
+                var cmdBufferBeginInfo = new MgCommandBufferBeginInfo
+                {
+
+                };
+
+                IMgCommandBuffer copyCmd = getCommandBuffer(true);
+
+                copyCmd.CmdCopyBuffer(
+                    stagingBuffers.vertices.buffer,
+                    vertices.buffer,
+                    new[]
+                    {
+                        new MgBufferCopy
+                        {
+                            Size = vertexBufferSize,
+                        }
+                    }
+                );
+
+                copyCmd.CmdCopyBuffer(stagingBuffers.indices.buffer, indices.buffer,
+                    new[]
+                    {
+                        new MgBufferCopy
+                        {
+                            Size = indexBufferSize,
+                        }
+                    });
+
+                flushCommandBuffer(copyCmd);
+
+                stagingBuffers.vertices.buffer.DestroyBuffer(mConfiguration.Device, null);
+                stagingBuffers.vertices.memory.FreeMemory(mConfiguration.Device, null);
+                stagingBuffers.indices.buffer.DestroyBuffer(mConfiguration.Device, null);
+                stagingBuffers.indices.memory.FreeMemory(mConfiguration.Device, null);
+            }
+
+            const uint VERTEX_BUFFER_BIND_ID = 0;
+
+            vertices.inputBinding = new MgVertexInputBindingDescription
+            {
+                Binding = VERTEX_BUFFER_BIND_ID,
+                Stride = (uint) structSize,
+                InputRate = MgVertexInputRate.VERTEX,
+            };
+
+            var vertexSize = (uint) Marshal.SizeOf(typeof(Vector3));
+
+            vertices.inputAttributes = new MgVertexInputAttributeDescription[]
+            {
+                new MgVertexInputAttributeDescription
+                {
+                    Binding = VERTEX_BUFFER_BIND_ID,
+                    Location = 0,
+                    Format =  MgFormat.R32G32B32_SFLOAT,
+                    Offset = 0,
+                },                             
+                new MgVertexInputAttributeDescription
+                {
+                    Binding = VERTEX_BUFFER_BIND_ID,
+                    Location = 1,
+                    Format = MgFormat.R32G32B32_SFLOAT,
+                    Offset = vertexSize,
+                }
+            };
+
+            vertices.inputState = new MgPipelineVertexInputStateCreateInfo
+            {
+                VertexBindingDescriptions = new MgVertexInputBindingDescription[]
+                {
+                    vertices.inputBinding,
+                },
+                VertexAttributeDescriptions = vertices.inputAttributes,
+            };                
+        }
+        IMgCommandBuffer getCommandBuffer(bool begin)
+        {
+            var buffers = new IMgCommandBuffer[1];
+
+            var cmdBufAllocateInfo = new MgCommandBufferAllocateInfo
+            {
+                CommandPool = mConfiguration.Partition.CommandPool,
+                Level =  MgCommandBufferLevel.PRIMARY,
+                CommandBufferCount = 1,
+            };
+
+            var err = mConfiguration.Device.AllocateCommandBuffers(cmdBufAllocateInfo, buffers);
+            Debug.Assert(err == Result.SUCCESS);
+
+            var cmdBuf = buffers[0];
+
+            if (begin)
+            {
+                var cmdBufInfo = new MgCommandBufferBeginInfo();
+
+                err = cmdBuf.BeginCommandBuffer(cmdBufInfo);
+                Debug.Assert(err == Result.SUCCESS);
+            }
+
+            return cmdBuf;
+        }
+
+        void flushCommandBuffer(IMgCommandBuffer commandBuffer)
+        {
+            Debug.Assert(commandBuffer != null);
+
+            var err = commandBuffer.EndCommandBuffer();
+            Debug.Assert(err == Result.SUCCESS);
+
+            var submitInfos = new [] 
+            {
+                new MgSubmitInfo
+                {
+                    CommandBuffers = new []
+                    {
+                        commandBuffer
+                    }
+                }
+            };
+
+            var fenceCreateInfo = new MgFenceCreateInfo();
+
+            err = mConfiguration.Device.CreateFence(fenceCreateInfo, null, out IMgFence fence);
+            Debug.Assert(err == Result.SUCCESS);
+
+            err = mConfiguration.Queue.QueueSubmit(submitInfos, fence);
+            Debug.Assert(err == Result.SUCCESS);
+
+            err = mConfiguration.Queue.QueueWaitIdle();
+            Debug.Assert(err == Result.SUCCESS);
+
+            err = mConfiguration.Device.WaitForFences(new[] { fence }, true, ulong.MaxValue);
+            Debug.Assert(err == Result.SUCCESS);
+
+            fence.DestroyFence(mConfiguration.Device, null);
+            mConfiguration.Device.FreeCommandBuffers(mConfiguration.Partition.CommandPool, new[] { commandBuffer } );
+        }
+
+        void PrepareUniformBuffers()
+        {
+            var structSize = (uint)Marshal.SizeOf(typeof(UniformBufferObject));
+
+            MgBufferCreateInfo bufferInfo = new MgBufferCreateInfo
+            {
+                Size = structSize,
+                Usage = MgBufferUsageFlagBits.UNIFORM_BUFFER_BIT,
+            };
+
+            var err = mConfiguration.Device.CreateBuffer(bufferInfo, null, out uniformDataVS.buffer);
+            Debug.Assert(err == Result.SUCCESS);
+
+            mConfiguration.Device.GetBufferMemoryRequirements(uniformDataVS.buffer, out MgMemoryRequirements memReqs);
+
+            var isValid = mConfiguration.Partition.GetMemoryType(memReqs.MemoryTypeBits, MgMemoryPropertyFlagBits.HOST_VISIBLE_BIT | MgMemoryPropertyFlagBits.HOST_COHERENT_BIT, out uint typeIndex);
+            Debug.Assert(isValid);
+
+            MgMemoryAllocateInfo allocInfo = new MgMemoryAllocateInfo
+            {
+                AllocationSize = memReqs.Size,
+                MemoryTypeIndex = typeIndex,
+            };
+
+            err = mConfiguration.Device.AllocateMemory(allocInfo, null, out uniformDataVS.memory);
+            Debug.Assert(err == Result.SUCCESS);
+
+            err = uniformDataVS.buffer.BindBufferMemory(mConfiguration.Device, uniformDataVS.memory, 0);
+            Debug.Assert(err == Result.SUCCESS);
+
+            uniformDataVS.descriptor = new MgDescriptorBufferInfo
+            {
+                Buffer = uniformDataVS.buffer,
+                Offset = 0,
+                Range = structSize,
+            };
+
+            UpdateUniformBuffers();
+        }
+
+
+        void SetupDescriptorSetLayout()
+        {
+            var descriptorLayout = new MgDescriptorSetLayoutCreateInfo
+            {
+                Bindings = new[]
+                {
+                    new MgDescriptorSetLayoutBinding
+                    {
+                        DescriptorCount = 1,
+                        StageFlags = MgShaderStageFlagBits.VERTEX_BIT,
+                        ImmutableSamplers = null,
+                        DescriptorType = MgDescriptorType.UNIFORM_BUFFER,
+                        Binding = 0,                         
+                    }
+                },
+            };
+
+            var err = mConfiguration.Device.CreateDescriptorSetLayout(descriptorLayout, null, out mDescriptorSetLayout);
+            Debug.Assert(err == Result.SUCCESS);
+
+            var pPipelineLayoutCreateInfo = new MgPipelineLayoutCreateInfo
+            {
+                 SetLayouts = new IMgDescriptorSetLayout[]
+                 {
+                     mDescriptorSetLayout,
+                 }
+            };
+
+            err = mConfiguration.Device.CreatePipelineLayout(pPipelineLayoutCreateInfo, null, out mPipelineLayout);
+            Debug.Assert(err == Result.SUCCESS);
+        }
+
+        void PreparePipelines()
+        {
+            using (var vertFs = mTrianglePath.OpenVertexShader())
+            using (var fragFs = mTrianglePath.OpenFragmentShader())
+            {
+                IMgShaderModule vsModule;
+                {
+                    var vsCreateInfo = new MgShaderModuleCreateInfo
+                    {
+                        Code = vertFs,
+                        CodeSize = new UIntPtr((ulong)vertFs.Length),
+                    };
+                    mConfiguration.Device.CreateShaderModule(vsCreateInfo, null, out vsModule);
+                }
+
+                IMgShaderModule fsModule;
+                {
+                    var fsCreateInfo = new MgShaderModuleCreateInfo
+                    {
+                        Code = fragFs,
+                        CodeSize = new UIntPtr((ulong)fragFs.Length),
+                    };
+                    mConfiguration.Device.CreateShaderModule(fsCreateInfo, null, out fsModule);
+                }
+
+                var pipelineCreateInfo = new MgGraphicsPipelineCreateInfo
+                {
+                    Stages = new []
+                    {
+                        new MgPipelineShaderStageCreateInfo
+                        {
+                            Stage = MgShaderStageFlagBits.VERTEX_BIT,
+                            Module = vsModule,
+                            Name = "vertFunc",
+                        },
+                        new MgPipelineShaderStageCreateInfo
+                        {
+                            Stage = MgShaderStageFlagBits.FRAGMENT_BIT,
+                            Module = fsModule,
+                            Name = "fragFunc",
+                        },
+                    },
+                    VertexInputState = vertices.inputState,
+                    InputAssemblyState = new MgPipelineInputAssemblyStateCreateInfo
+                    {
+                        // GL002 - TRIANGLE STRIP TEST
+                        Topology = MgPrimitiveTopology.TRIANGLE_STRIP,
+                    },
+                    RasterizationState = new MgPipelineRasterizationStateCreateInfo
+                    {
+                        PolygonMode = MgPolygonMode.FILL,
+                        CullMode = MgCullModeFlagBits.NONE,
+                        FrontFace = MgFrontFace.COUNTER_CLOCKWISE,
+                        DepthClampEnable = false,
+                        RasterizerDiscardEnable = false,
+                        DepthBiasEnable = false,
+                        LineWidth = 1.0f,
+                    },
+                    ColorBlendState = new MgPipelineColorBlendStateCreateInfo
+                    {
+                        Attachments = new []
+                        {
+                            new MgPipelineColorBlendAttachmentState
+                            {
+                                ColorWriteMask =  MgColorComponentFlagBits.R_BIT | MgColorComponentFlagBits.G_BIT | MgColorComponentFlagBits.B_BIT | MgColorComponentFlagBits.A_BIT,
+                                BlendEnable = false,
+                            }
+                        },
+                    },
+                    MultisampleState = new MgPipelineMultisampleStateCreateInfo
+                    {
+                        RasterizationSamples = MgSampleCountFlagBits.COUNT_1_BIT,
+                        SampleMask = null,
+                    },
+                    Layout = mPipelineLayout,
+                    RenderPass = mGraphicsDevice.Renderpass,
+                    ViewportState = null,
+                    DepthStencilState = new MgPipelineDepthStencilStateCreateInfo
+                    {
+                        DepthTestEnable = true,
+                        DepthWriteEnable = true,
+                        DepthCompareOp = MgCompareOp.LESS_OR_EQUAL,
+                        DepthBoundsTestEnable = false,
+                        Back = new MgStencilOpState
+                        {
+                            FailOp = MgStencilOp.KEEP,
+                            PassOp = MgStencilOp.KEEP,
+                            CompareOp = MgCompareOp.ALWAYS,
+                        },
+                        StencilTestEnable = false,
+                        Front = new MgStencilOpState
+                        {
+                            FailOp = MgStencilOp.KEEP,
+                            PassOp = MgStencilOp.KEEP,
+                            CompareOp = MgCompareOp.ALWAYS,
+                        },
+                    },
+                    DynamicState = new MgPipelineDynamicStateCreateInfo
+                    {
+                        DynamicStates = new[]
+                        {
+                            MgDynamicState.VIEWPORT,
+                            MgDynamicState.SCISSOR,
+                        }
+                    },
+                };
+
+                var err = mConfiguration.Device.CreateGraphicsPipelines(null, new[] { pipelineCreateInfo }, null, out IMgPipeline[] pipelines);
+                Debug.Assert(err == Result.SUCCESS);
+
+                vsModule.DestroyShaderModule(mConfiguration.Device, null);
+                fsModule.DestroyShaderModule(mConfiguration.Device, null);
+
+                mPipeline = pipelines[0];
+            }
+
+        }
+
+        void SetupDescriptorPool()
+        {
+            var descriptorPoolInfo = new MgDescriptorPoolCreateInfo
+            {
+                PoolSizes = new MgDescriptorPoolSize[]
+                {
+                    new MgDescriptorPoolSize
+                    {
+                        Type = MgDescriptorType.UNIFORM_BUFFER,
+                        DescriptorCount = 1,
+                    },
+                },
+                MaxSets = 1,
+            };
+            var err = mConfiguration.Device.CreateDescriptorPool(descriptorPoolInfo, null, out mDescriptorPool);
+            Debug.Assert(err == Result.SUCCESS);
+        }
+
+        void SetupDescriptorSet()
+        {
+            var allocInfo = new MgDescriptorSetAllocateInfo
+            {
+                DescriptorPool = mDescriptorPool,
+                DescriptorSetCount = 1,
+                SetLayouts = new[] { mDescriptorSetLayout },
+            };
+
+            IMgDescriptorSet[] dSets;
+            var err = mConfiguration.Device.AllocateDescriptorSets(allocInfo, out dSets);
+            mDescriptorSet = dSets[0];
+
+            Debug.Assert(err == Result.SUCCESS);
+            mConfiguration.Device.UpdateDescriptorSets(
+                new []
+                {
+                    new MgWriteDescriptorSet
+                    {
+                        DstSet = mDescriptorSet,
+                        DescriptorCount = 1,
+                        DescriptorType =  MgDescriptorType.UNIFORM_BUFFER,
+                        BufferInfo = new MgDescriptorBufferInfo[]
+                        {
+                            uniformDataVS.descriptor,
+                        },
+                        DstBinding = 0,
+                    },
+                }, null);
+        }
+
+        IMgCommandBuffer[] drawCmdBuffers;
+
+        void CreateCommandBuffers()
+        {
+            drawCmdBuffers = new IMgCommandBuffer[mGraphicsDevice.Framebuffers.Length];
+
+            {
+                var cmdBufAllocateInfo = new MgCommandBufferAllocateInfo
+                {
+                    CommandBufferCount = (uint)mGraphicsDevice.Framebuffers.Length,
+                    CommandPool = mConfiguration.Partition.CommandPool,
+                    Level = MgCommandBufferLevel.PRIMARY,
+                };
+
+                var err = mConfiguration.Device.AllocateCommandBuffers(cmdBufAllocateInfo, drawCmdBuffers);
+                Debug.Assert(err == Result.SUCCESS);
+            }
+
+            {
+                var cmdBufAllocateInfo = new MgCommandBufferAllocateInfo
+                {
+                    CommandBufferCount = 2,
+                    CommandPool = mConfiguration.Partition.CommandPool,
+                    Level = MgCommandBufferLevel.PRIMARY,
+                };
+  
+                var presentBuffers = new IMgCommandBuffer[2];
+                var err = mConfiguration.Device.AllocateCommandBuffers(cmdBufAllocateInfo, presentBuffers);
+                Debug.Assert(err == Result.SUCCESS);
+
+                mPrePresentCmdBuffer = presentBuffers[0];
+                mPostPresentCmdBuffer = presentBuffers[1];
+            }
+        }
+
+        void BuildCommandBuffers()
+        {
+            var renderPassBeginInfo = new MgRenderPassBeginInfo {
+                RenderPass = mGraphicsDevice.Renderpass,
+                RenderArea = new MgRect2D
+                {
+                    Offset = new MgOffset2D {  X = 0, Y = 0 },
+                    Extent = new MgExtent2D { Width = mWidth, Height = mHeight },
+                },
+                ClearValues = new MgClearValue[]
+                {
+                    MgClearValue.FromColorAndFormat(mSwapchains.Format, new MgColor4f(0f, 0f, 0f, 0f)),                    
+                    new MgClearValue { DepthStencil = new MgClearDepthStencilValue( 1.0f, 0) },
+                },
+            };
+            
+            for (var i = 0; i < drawCmdBuffers.Length; ++i)
+            {
+                renderPassBeginInfo.Framebuffer = mGraphicsDevice.Framebuffers[i];
+
+                var cmdBuf = drawCmdBuffers[i];
+
+                var cmdBufInfo = new MgCommandBufferBeginInfo { };
+                var err = cmdBuf.BeginCommandBuffer(cmdBufInfo);
+                Debug.Assert(err == Result.SUCCESS);
+
+                cmdBuf.CmdBeginRenderPass(renderPassBeginInfo, MgSubpassContents.INLINE);
+
+                cmdBuf.CmdSetViewport(0, 
+                    new[] {
+                        new MgViewport {
+                            Height = (float) mHeight,
+                            Width = (float) mWidth,
+                            MinDepth = 0.0f,
+                            MaxDepth = 1.0f,
+                        }
+                    }
+                );
+
+                cmdBuf.CmdSetScissor(0,
+                    new[] {
+                        new MgRect2D {
+                            Extent = new MgExtent2D { Width = mWidth, Height = mHeight },
+                            Offset = new MgOffset2D { X = 0, Y = 0 },
+                        }
+                    }
+                );
+
+                cmdBuf.CmdBindDescriptorSets( MgPipelineBindPoint.GRAPHICS, mPipelineLayout, 0, 1, new[] { mDescriptorSet }, null);
+
+                cmdBuf.CmdBindPipeline(MgPipelineBindPoint.GRAPHICS, mPipeline);
+
+                cmdBuf.CmdBindVertexBuffers(0, new[] { vertices.buffer }, new [] { 0UL });
+
+                cmdBuf.CmdBindIndexBuffer(indices.buffer, 0, MgIndexType.UINT32);
+
+                cmdBuf.CmdDrawIndexed(indices.count, 1, 0, 0, 1);
+
+                cmdBuf.CmdEndRenderPass();
+
+                err = cmdBuf.EndCommandBuffer();
+                Debug.Assert(err == Result.SUCCESS);
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Convert degrees to radians
+        /// </summary>
+        /// <param name="degrees">An angle in degrees</param>
+        /// <returns>The angle expressed in radians</returns>
+        public static float DegreesToRadians(float degrees)
+        {
+            const double degToRad = System.Math.PI / 180.0;
+            return (float) (degrees * degToRad);
+        }
+
+        void UpdateUniformBuffers()
+        {
+            // Update matrices
+            uboVS.projectionMatrix = Matrix4.CreatePerspectiveFieldOfView(
+                DegreesToRadians(60.0f), 
+                (mWidth / mHeight), 
+                1.0f,
+                256.0f);
+
+            const float ZOOM = -2.5f;
+
+            uboVS.viewMatrix = Matrix4.CreateTranslation(0, 0, ZOOM);
+
+            uboVS.modelMatrix = Matrix4.Identity;
+
+            var structSize = (ulong) Marshal.SizeOf(typeof(UniformBufferObject));
+
+            var err = uniformDataVS.memory.MapMemory(mConfiguration.Device, 0, structSize, 0, out IntPtr pData);
+
+            Marshal.StructureToPtr(uboVS, pData, false);
+            uniformDataVS.memory.UnmapMemory(mConfiguration.Device);
+        }
+
+        public void RenderLoop()
+        {
+            render();
+        }
+
+        void render()
+        {
+            if (!mPrepared)
+                return;
+            Draw();
+        }
+
+        void Draw()
+        {
+            var currentBufferIndex = mPresentationLayer.BeginDraw(mPostPresentCmdBuffer, mPresentCompleteSemaphore);
+
+            var fence = mWaitFences[(int) currentBufferIndex];
+            var err = mConfiguration.Device.WaitForFences(new[] { fence } , true, ulong.MaxValue);
+            Debug.Assert(err == Result.SUCCESS);
+
+            err = mConfiguration.Device.ResetFences(new[] { fence });
+
+            var submitInfos = new MgSubmitInfo[]
+            {
+                new MgSubmitInfo
+                {
+                    WaitSemaphores = new []
+                    {
+                        new MgSubmitInfoWaitSemaphoreInfo
+                        {
+                            WaitDstStageMask =  MgPipelineStageFlagBits.COLOR_ATTACHMENT_OUTPUT_BIT,
+                            WaitSemaphore = mPresentCompleteSemaphore,
+                        }
+                    },
+                    CommandBuffers = new []
+                    {
+                        drawCmdBuffers[currentBufferIndex]
+                    },
+                    SignalSemaphores = new []
+                    {
+                        mRenderCompleteSemaphore
+                    },                    
+                }
+            };                                        
+
+            err = mConfiguration.Queue.QueueSubmit(submitInfos, fence);
+            Debug.Assert(err == Result.SUCCESS);
+            mPresentationLayer.EndDraw(new[] { currentBufferIndex }, mPrePresentCmdBuffer, new[] { mRenderCompleteSemaphore });
+        }
+
+        void ViewChanged()
+        {
+            UpdateUniformBuffers();
+        }
+
+        #region IDisposable Support
+        private bool mIsDisposed = false; // To detect redundant calls
+        private ITriangleDemoShaderPath mTrianglePath;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (mIsDisposed)
+            {
+                return;
+            }
+
+            ReleaseUnmanagedResources();
+
+            if (disposing)
+            {  
+                ReleaseManagedResources();
+            }
+
+            mIsDisposed = true;            
+        }
+
+        private void ReleaseManagedResources()
+        {
+           
+        }
+
+        private void ReleaseUnmanagedResources()
+        {
+            var device = mConfiguration.Device;
+            if (device != null)
+            {
+                if (mPipeline != null)
+                    mPipeline.DestroyPipeline(device, null);
+
+                if (mPipelineLayout != null)
+                    mPipelineLayout.DestroyPipelineLayout(device, null);
+
+                if (mDescriptorSetLayout != null)
+                    mDescriptorSetLayout.DestroyDescriptorSetLayout(device, null);
+
+                if (vertices.buffer != null)
+                    vertices.buffer.DestroyBuffer(device, null);
+
+                if (vertices.memory != null)
+                    vertices.memory.FreeMemory(device, null);
+
+                if (indices.buffer != null)
+                    indices.buffer.DestroyBuffer(device, null);
+
+                if (indices.memory != null)
+                    indices.memory.FreeMemory(device, null);
+
+                if (uniformDataVS.buffer != null)
+                    uniformDataVS.buffer.DestroyBuffer(device, null);
+
+                if (uniformDataVS.memory != null)
+                    uniformDataVS.memory.FreeMemory(device, null);
+
+                if (mPresentCompleteSemaphore != null)
+                    mPresentCompleteSemaphore.DestroySemaphore(device, null);
+
+
+                if (mRenderCompleteSemaphore != null)
+                    mRenderCompleteSemaphore.DestroySemaphore(device, null);
+
+                foreach (var fence in mWaitFences)
+                {
+                    fence.DestroyFence(device, null);
+                }
+
+                if (mDescriptorPool != null)
+                    mDescriptorPool.DestroyDescriptorPool(device, null);
+
+                if (drawCmdBuffers != null)
+                    mConfiguration.Device.FreeCommandBuffers(mConfiguration.Partition.CommandPool, drawCmdBuffers);
+
+                if (mPostPresentCmdBuffer != null)
+                    mConfiguration.Device.FreeCommandBuffers(mConfiguration.Partition.CommandPool, new[] { mPostPresentCmdBuffer });
+
+
+                if (mPrePresentCmdBuffer != null)
+                    mConfiguration.Device.FreeCommandBuffers(mConfiguration.Partition.CommandPool, new[] { mPrePresentCmdBuffer });
+
+                if (mGraphicsDevice != null)
+                    mGraphicsDevice.Dispose();
+            }
+        }
+
+        ~VulkanExample()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/tests/GL002/GL002.Demo/packages.config
+++ b/tests/GL002/GL002.Demo/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LightInject" version="4.1.5" targetFramework="net452" />
+  <package id="Magnesium" version="5.2.8-beta" targetFramework="net452" />
+  <package id="Magnesium.PresentationSurfaces.OpenTK" version="1.0.4-beta" targetFramework="net452" />
+  <package id="OpenTK" version="2.0.0" targetFramework="net452" />
+</packages>

--- a/tests/GL002/GL002.UnitTests.sln
+++ b/tests/GL002/GL002.UnitTests.sln
@@ -1,0 +1,93 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.16
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Magnesium.OpenGL.DesktopGL", "..\..\Magnesium.OpenGL.DesktopGL\Magnesium.OpenGL.DesktopGL.csproj", "{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GL002.UnitTests", "GL002.UnitTests\GL002.UnitTests.csproj", "{E0DED9AF-AB03-425A-BFAB-83C239BED98A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Magnesium", "..\..\Magnesium\Magnesium.csproj", "{9F9AC448-9D17-43E5-8889-285426290891}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GL002.Demo", "GL002.Demo\GL002.Demo.csproj", "{3177B351-BD6A-46C2-A989-EBD66BA965B5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Magnesium.OpenGL", "..\..\Magnesium.OpenGL\Magnesium.OpenGL.csproj", "{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Debug|x64.ActiveCfg = Debug|x64
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Debug|x64.Build.0 = Debug|x64
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Debug|x86.ActiveCfg = Debug|x86
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Debug|x86.Build.0 = Debug|x86
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Release|x64.ActiveCfg = Release|x64
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Release|x64.Build.0 = Release|x64
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Release|x86.ActiveCfg = Release|x86
+		{156D7F9D-1243-4EDB-9E45-24FAF2F40A4C}.Release|x86.Build.0 = Release|x86
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Debug|x64.Build.0 = Debug|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Debug|x86.Build.0 = Debug|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Release|x64.ActiveCfg = Release|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Release|x64.Build.0 = Release|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Release|x86.ActiveCfg = Release|Any CPU
+		{E0DED9AF-AB03-425A-BFAB-83C239BED98A}.Release|x86.Build.0 = Release|Any CPU
+		{9F9AC448-9D17-43E5-8889-285426290891}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9F9AC448-9D17-43E5-8889-285426290891}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9F9AC448-9D17-43E5-8889-285426290891}.Debug|x64.ActiveCfg = Debug|x64
+		{9F9AC448-9D17-43E5-8889-285426290891}.Debug|x64.Build.0 = Debug|x64
+		{9F9AC448-9D17-43E5-8889-285426290891}.Debug|x86.ActiveCfg = Debug|x86
+		{9F9AC448-9D17-43E5-8889-285426290891}.Debug|x86.Build.0 = Debug|x86
+		{9F9AC448-9D17-43E5-8889-285426290891}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9F9AC448-9D17-43E5-8889-285426290891}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9F9AC448-9D17-43E5-8889-285426290891}.Release|x64.ActiveCfg = Release|x64
+		{9F9AC448-9D17-43E5-8889-285426290891}.Release|x64.Build.0 = Release|x64
+		{9F9AC448-9D17-43E5-8889-285426290891}.Release|x86.ActiveCfg = Release|x86
+		{9F9AC448-9D17-43E5-8889-285426290891}.Release|x86.Build.0 = Release|x86
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Debug|x64.ActiveCfg = Debug|x64
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Debug|x64.Build.0 = Debug|x64
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Debug|x86.ActiveCfg = Debug|x86
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Debug|x86.Build.0 = Debug|x86
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Release|x64.ActiveCfg = Release|x64
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Release|x64.Build.0 = Release|x64
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Release|x86.ActiveCfg = Release|x86
+		{3177B351-BD6A-46C2-A989-EBD66BA965B5}.Release|x86.Build.0 = Release|x86
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Debug|x64.ActiveCfg = Debug|x64
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Debug|x64.Build.0 = Debug|x64
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Debug|x86.ActiveCfg = Debug|x86
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Debug|x86.Build.0 = Debug|x86
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Release|x64.ActiveCfg = Release|x64
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Release|x64.Build.0 = Release|x64
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Release|x86.ActiveCfg = Release|x86
+		{84924A0F-0D4C-4B0C-B16A-4F26DD838AF2}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0AF911ED-A5E8-43C3-B4AB-AF911D654FC7}
+	EndGlobalSection
+EndGlobal

--- a/tests/GL002/GL002.UnitTests/GL002.UnitTests.csproj
+++ b/tests/GL002/GL002.UnitTests/GL002.UnitTests.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E0DED9AF-AB03-425A-BFAB-83C239BED98A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Magnesium.OpenGL.DesktopGL.UnitTests</RootNamespace>
+    <AssemblyName>Magnesium.OpenGL.DesktopGL.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTK">
+      <HintPath>..\..\..\bin\Debug\OpenTK.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Magnesium.OpenGL.DesktopGL\Magnesium.OpenGL.DesktopGL.csproj">
+      <Project>{156d7f9d-1243-4edb-9e45-24faf2f40a4c}</Project>
+      <Name>Magnesium.OpenGL.DesktopGL</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Magnesium\Magnesium.csproj">
+      <Project>{9f9ac448-9d17-43e5-8889-285426290891}</Project>
+      <Name>Magnesium</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/tests/GL002/GL002.UnitTests/Properties/AssemblyInfo.cs
+++ b/tests/GL002/GL002.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Magnesium.OpenGL.DesktopGL.UnitTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Magnesium.OpenGL.DesktopGL.UnitTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("e0ded9af-ab03-425a-bfab-83c239bed98a")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/GL002/GL002.UnitTests/UnitTest1.cs
+++ b/tests/GL002/GL002.UnitTests/UnitTest1.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenTK.Graphics.OpenGL;
+
+namespace Magnesium.OpenGL.DesktopGL.UnitTests
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void UnitTest()
+        {
+            var actual = FullGLCmdDrawEntrypoint.GetPrimitiveType(Magnesium.MgPrimitiveTopology.LINE_STRIP);
+            Assert.AreEqual(PrimitiveType.LineStrip, actual);
+        }
+    }
+}

--- a/tests/GL002/GL002.UnitTests/packages.config
+++ b/tests/GL002/GL002.UnitTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net45" />
+  <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
When rendering a triangle strip with Mg.DesktopGL polyfill implementation, a GL_INVALID_VALUE error value is raised after exiting the application.

Bug in FullGLCmdDrawEntrypoint, a line strip value was missing from the function GetPrimitiveType

Patch adds unit tests
