### PR TITLE
v700 - Removed descriptorCount from IMgCommandBuffer.bindDescriptorSets

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,7 @@ Magnesium and its implementations uses [Semantic Versioning v2.0.0](http://semve
  	- Refactored GetMemoryType to MgPhysicalDeviceMemoryProperties and MgGraphicsConfiguration
 	- Changed MgGraphicsDeviceCreateInfo to either auto-detect (default) or override color format of the graphics device
 	- Changed MgGraphicsDeviceCreateInfo to either auto-detect (default), override, or disable (use none) depth/stencil format of the graphics device
+	- Removed descriptorCount from IMgCommandBuffer.CmdBindDescriptorSets because it was redundant
 
 ## Version 5.2.8-beta
  - Magnesium v5.2.8 - 2 Sep 2017

--- a/Magnesium.OpenGL/CommandBuffer/GLCmdCommandBuffer.cs
+++ b/Magnesium.OpenGL/CommandBuffer/GLCmdCommandBuffer.cs
@@ -141,13 +141,13 @@ namespace Magnesium.OpenGL.Internals
 			MgPipelineBindPoint pipelineBindPoint,
 			IMgPipelineLayout layout,
 			uint firstSet,
-			uint descriptorSetCount,
 			IMgDescriptorSet[] pDescriptorSets,
 			uint[] pDynamicOffsets)
 		{
 			if (pipelineBindPoint == MgPipelineBindPoint.GRAPHICS)
 			{
-				mCommandEncoder.Graphics.BindDescriptorSets(layout,
+                uint descriptorSetCount = pDescriptorSets != null ? (uint) pDescriptorSets.Length : 0U;
+                mCommandEncoder.Graphics.BindDescriptorSets(layout,
 															firstSet,
 															descriptorSetCount,
 															pDescriptorSets,

--- a/Magnesium.Vulkan/Handles/VkCommandBuffer.cs
+++ b/Magnesium.Vulkan/Handles/VkCommandBuffer.cs
@@ -181,13 +181,14 @@ namespace Magnesium.Vulkan
 			Interops.vkCmdSetStencilReference(this.Handle, (VkStencilFaceFlags)faceMask, reference);
 		}
 
-		public void CmdBindDescriptorSets(MgPipelineBindPoint pipelineBindPoint, IMgPipelineLayout layout, UInt32 firstSet, UInt32 descriptorSetCount, IMgDescriptorSet[] pDescriptorSets, UInt32[] pDynamicOffsets)
+		public void CmdBindDescriptorSets(MgPipelineBindPoint pipelineBindPoint, IMgPipelineLayout layout, UInt32 firstSet, IMgDescriptorSet[] pDescriptorSets, UInt32[] pDynamicOffsets)
 		{
 
             var bLayout = (VkPipelineLayout)layout;
             Debug.Assert(bLayout != null);
 
             var stride = Marshal.SizeOf(typeof(IntPtr));
+            var descriptorSetCount = pDescriptorSets != null ? (uint) pDescriptorSets.Length : 0U;
             IntPtr sets = Marshal.AllocHGlobal((int)(stride * descriptorSetCount));
 
             var src = new ulong[descriptorSetCount];

--- a/Magnesium/CommandBuffer/IMgCommandBuffer.cs
+++ b/Magnesium/CommandBuffer/IMgCommandBuffer.cs
@@ -18,7 +18,7 @@ namespace Magnesium
 		void CmdSetStencilCompareMask(MgStencilFaceFlagBits faceMask, UInt32 compareMask);
 		void CmdSetStencilWriteMask(MgStencilFaceFlagBits faceMask, UInt32 writeMask);
 		void CmdSetStencilReference(MgStencilFaceFlagBits faceMask, UInt32 reference);
-		void CmdBindDescriptorSets(MgPipelineBindPoint pipelineBindPoint, IMgPipelineLayout layout, UInt32 firstSet, UInt32 descriptorSetCount, IMgDescriptorSet[] pDescriptorSets, UInt32[] pDynamicOffsets);
+		void CmdBindDescriptorSets(MgPipelineBindPoint pipelineBindPoint, IMgPipelineLayout layout, UInt32 firstSet, IMgDescriptorSet[] pDescriptorSets, UInt32[] pDynamicOffsets);
 		void CmdBindIndexBuffer(IMgBuffer buffer, UInt64 offset, MgIndexType indexType);
 		void CmdBindVertexBuffers(UInt32 firstBinding, IMgBuffer[] pBuffers, UInt64[] pOffsets);
 		void CmdDraw(UInt32 vertexCount, UInt32 instanceCount, UInt32 firstVertex, UInt32 firstInstance);


### PR DESCRIPTION
Removed descriptorCount from IMgCommandBuffer.bindDescriptorSets.

Affects Magnesium interface and all implementations