### PR TITLE
v700 - Change to MgGraphicsDeviceCreateInfo 

### DIFF
--- a/Magnesium/Driver/MgDeviceFormatSetting.cs
+++ b/Magnesium/Driver/MgDeviceFormatSetting.cs
@@ -1,0 +1,11 @@
+﻿namespace Magnesium
+{
+    public struct MgDeviceFormatSetting
+    {
+        public MgColorFormatOption Color { get; set; }
+        public MgFormat OverrideColor { get; set; }
+        public MgDepthFormatOption DepthStencil { get; set; }
+        public MgFormat OverrideDepthStencil { get; set; }
+    }
+}
+

--- a/Magnesium/Driver/MgGraphicsDeviceCreateInfo.cs
+++ b/Magnesium/Driver/MgGraphicsDeviceCreateInfo.cs
@@ -2,14 +2,14 @@
 
 namespace Magnesium
 {
-	public class MgGraphicsDeviceCreateInfo
+    public class MgGraphicsDeviceCreateInfo
 	{
 		public UInt32 Width { get; set; }
 		public UInt32 Height { get; set;}
-        public MgColorFormatOption Color { get; set; }
-		public MgFormat OverrideColor { get; set; }
-        public MgDepthFormatOption DepthStencil { get; set; }
-		public MgFormat OverrideDepthStencil { get; set;}
+
+        public MgDeviceFormatSetting Swapchain { get; set; }
+        public MgDeviceFormatSetting RenderPass { get; set; }
+
         public MgSampleCountFlagBits Samples { get; set; }
 	}
 }

--- a/Magnesium/Magnesium.csproj
+++ b/Magnesium/Magnesium.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Driver\IMgPresentationLayer.cs" />
     <Compile Include="Driver\MgColorFormatOption.cs" />
     <Compile Include="Driver\MgDefaultGraphicsConfiguration.cs" />
+    <Compile Include="Driver\MgDeviceFormatSetting.cs" />
     <Compile Include="Driver\MgFormatNotSupportedException.cs" />
     <Compile Include="Driver\MgDepthFormatOption.cs" />
     <Compile Include="Driver\MgFramebufferCollection.cs" />

--- a/examples/TextureDemo/TextureExample.cs
+++ b/examples/TextureDemo/TextureExample.cs
@@ -35,8 +35,13 @@ namespace TextureDemo
             var createInfo = new MgGraphicsDeviceCreateInfo
             {
                 Samples = MgSampleCountFlagBits.COUNT_1_BIT,
-                Color = MgFormat.R8G8B8A8_UINT,
-                DepthStencil = MgFormat.X8_D24_UNORM_PACK32,
+                RenderPass = new MgDeviceFormatSetting
+                {
+                    Color = MgColorFormatOption.USE_OVERRIDE,
+                    OverrideColor = MgFormat.R8G8B8A8_UINT,
+                    DepthStencil = MgDepthFormatOption.USE_OVERRIDE,
+                    OverrideDepthStencil = MgFormat.X8_D24_UNORM_PACK32,
+                },
                 Width = 1280,
                 Height = 720,
             };


### PR DESCRIPTION
Added properties to MgGraphicsDeviceCreateInfo to allow the  color and depth/stencil formats  renderpass & swapchains individually

Change required to fix TextureDemo example